### PR TITLE
feat(retrospective): Gemini API 기반 질문 생성 인프라 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+.env

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -38,3 +38,5 @@ out/
 
 ### Kotlin ###
 .kotlin
+
+.env

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/retrospective/infrastructure/external/gemini/GeminiApiDto.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/retrospective/infrastructure/external/gemini/GeminiApiDto.kt
@@ -1,0 +1,110 @@
+package xyz.robinjoon.growweek.retrospective.infrastructure.external.gemini
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * Gemini API 요청 DTO
+ */
+data class GeminiRequest(
+    val contents: List<Content>,
+    val generationConfig: GenerationConfig? = null
+) {
+    data class Content(
+        val parts: List<Part>
+    )
+
+    data class Part(
+        val text: String
+    )
+
+    data class GenerationConfig(
+        val thinkingConfig: ThinkingConfig? = null,
+        val responseMimeType: String? = null,
+        val responseSchema: ResponseSchema? = null
+    )
+
+    data class ThinkingConfig(
+        val thinkingLevel: String
+    )
+
+    data class ResponseSchema(
+        val type: String,
+        val items: SchemaItems? = null
+    )
+
+    data class SchemaItems(
+        val type: String
+    )
+
+    companion object {
+        fun createTextRequest(
+            prompt: String,
+            thinkingLevel: String = "low"
+        ): GeminiRequest {
+            return GeminiRequest(
+                contents = listOf(
+                    Content(parts = listOf(Part(text = prompt)))
+                ),
+                generationConfig = GenerationConfig(
+                    thinkingConfig = ThinkingConfig(thinkingLevel = thinkingLevel),
+                    responseMimeType = "application/json",
+                    responseSchema = ResponseSchema(
+                        type = "array",
+                        items = SchemaItems(type = "string")
+                    )
+                )
+            )
+        }
+    }
+}
+
+/**
+ * Gemini API 응답 DTO
+ */
+data class GeminiResponse(
+    val candidates: List<Candidate>?,
+    val usageMetadata: UsageMetadata? = null,
+    val modelVersion: String? = null,
+    val error: GeminiError? = null
+) {
+    data class Candidate(
+        val content: Content?,
+        val finishReason: String? = null,
+        val index: Int? = null
+    )
+
+    data class Content(
+        val parts: List<Part>?,
+        val role: String? = null
+    )
+
+    data class Part(
+        val text: String? = null,
+        val thought: Boolean? = null
+    )
+
+    data class UsageMetadata(
+        val promptTokenCount: Int? = null,
+        val candidatesTokenCount: Int? = null,
+        val totalTokenCount: Int? = null
+    )
+
+    data class GeminiError(
+        val code: Int?,
+        val message: String?,
+        val status: String?
+    )
+
+    /**
+     * 응답에서 텍스트 추출
+     */
+    fun extractText(): String? {
+        return candidates
+            ?.firstOrNull()
+            ?.content
+            ?.parts
+            ?.filter { it.thought != true }
+            ?.mapNotNull { it.text }
+            ?.joinToString("")
+    }
+}

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/retrospective/infrastructure/external/gemini/GeminiClient.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/retrospective/infrastructure/external/gemini/GeminiClient.kt
@@ -1,0 +1,69 @@
+package xyz.robinjoon.growweek.retrospective.infrastructure.external.gemini
+
+import org.slf4j.LoggerFactory
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestClient
+import org.springframework.web.client.RestClientException
+
+/**
+ * Gemini API 클라이언트
+ *
+ * REST API를 통해 Google Gemini 모델과 통신합니다.
+ */
+@Component
+class GeminiClient(
+    private val geminiProperties: GeminiProperties
+) {
+    private val logger = LoggerFactory.getLogger(GeminiClient::class.java)
+
+    private val restClient: RestClient = RestClient.builder()
+        .baseUrl(geminiProperties.baseUrl)
+        .defaultHeader("x-goog-api-key", geminiProperties.apiKey)
+        .defaultHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+        .build()
+
+    /**
+     * Gemini API에 텍스트 생성 요청
+     *
+     * @param prompt 프롬프트 텍스트
+     * @return 생성된 텍스트 응답
+     * @throws GeminiApiException API 호출 실패 시
+     */
+    fun generateContent(prompt: String): String {
+        val request = GeminiRequest.createTextRequest(
+            prompt = prompt,
+            thinkingLevel = geminiProperties.thinkingLevel
+        )
+
+        return try {
+            val response = restClient.post()
+                .uri("/v1beta/models/${geminiProperties.model}:generateContent")
+                .body(request)
+                .retrieve()
+                .body(GeminiResponse::class.java)
+
+            response?.let { geminiResponse ->
+                geminiResponse.error?.let { error ->
+                    logger.error("Gemini API error: ${error.message}")
+                    throw GeminiApiException("Gemini API 오류: ${error.message}", error.code)
+                }
+
+                geminiResponse.extractText()
+                    ?: throw GeminiApiException("Gemini API 응답에서 텍스트를 추출할 수 없습니다")
+            } ?: throw GeminiApiException("Gemini API 응답이 비어있습니다")
+        } catch (e: RestClientException) {
+            logger.error("Gemini API 호출 실패", e)
+            throw GeminiApiException("Gemini API 호출 실패: ${e.message}", cause = e)
+        }
+    }
+}
+
+/**
+ * Gemini API 예외
+ */
+class GeminiApiException(
+    message: String,
+    val errorCode: Int? = null,
+    cause: Throwable? = null
+) : RuntimeException(message, cause)

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/retrospective/infrastructure/external/gemini/GeminiConfig.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/retrospective/infrastructure/external/gemini/GeminiConfig.kt
@@ -1,0 +1,13 @@
+package xyz.robinjoon.growweek.retrospective.infrastructure.external.gemini
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Gemini API 설정 클래스
+ *
+ * GeminiProperties를 활성화합니다.
+ */
+@Configuration
+@EnableConfigurationProperties(GeminiProperties::class)
+class GeminiConfig

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/retrospective/infrastructure/external/gemini/GeminiProperties.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/retrospective/infrastructure/external/gemini/GeminiProperties.kt
@@ -1,0 +1,17 @@
+package xyz.robinjoon.growweek.retrospective.infrastructure.external.gemini
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.bind.ConstructorBinding
+
+/**
+ * Gemini API 설정 프로퍼티
+ *
+ * application.yaml의 gemini 설정을 바인딩합니다.
+ */
+@ConfigurationProperties(prefix = "gemini")
+data class GeminiProperties @ConstructorBinding constructor(
+    val apiKey: String,
+    val baseUrl: String = "https://generativelanguage.googleapis.com",
+    val model: String = "gemini-2.0-flash",
+    val thinkingLevel: String = "low"
+)

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/retrospective/infrastructure/external/gemini/GeminiQuestionGenerationService.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/retrospective/infrastructure/external/gemini/GeminiQuestionGenerationService.kt
@@ -1,0 +1,163 @@
+package xyz.robinjoon.growweek.retrospective.infrastructure.external.gemini
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Primary
+import org.springframework.stereotype.Service
+import xyz.robinjoon.growweek.retrospective.domain.model.QuestionCount
+import xyz.robinjoon.growweek.retrospective.domain.service.QuestionGenerationService
+import xyz.robinjoon.growweek.task.domain.model.Task
+
+/**
+ * Gemini API를 활용한 회고 질문 생성 서비스
+ *
+ * Google Gemini 모델을 사용하여 주간 할일 데이터를 기반으로
+ * 개인화된 회고 질문을 생성합니다.
+ */
+@Service
+@Primary
+@ConditionalOnProperty(prefix = "gemini", name = ["api-key"])
+class GeminiQuestionGenerationService(
+    private val geminiClient: GeminiClient
+) : QuestionGenerationService {
+
+    private val logger = LoggerFactory.getLogger(GeminiQuestionGenerationService::class.java)
+    private val objectMapper = jacksonObjectMapper()
+
+    override suspend fun generateQuestions(
+        tasks: List<Task>,
+        questionCount: QuestionCount
+    ): List<String> {
+        val prompt = buildPrompt(tasks, questionCount)
+
+        return try {
+            val response = geminiClient.generateContent(prompt)
+            parseQuestionsFromResponse(response, questionCount.value)
+        } catch (e: GeminiApiException) {
+            logger.warn("Gemini API 호출 실패, 기본 질문 반환: ${e.message}")
+            generateFallbackQuestions(tasks, questionCount)
+        } catch (e: Exception) {
+            logger.error("질문 생성 중 예외 발생", e)
+            generateFallbackQuestions(tasks, questionCount)
+        }
+    }
+
+    private fun buildPrompt(tasks: List<Task>, questionCount: QuestionCount): String {
+        val taskSummary = if (tasks.isEmpty()) {
+            "이번 주에 등록된 할일이 없습니다."
+        } else {
+            buildTaskSummary(tasks)
+        }
+
+        return """
+            당신은 개인 성장과 업무 효율성 향상을 돕는 회고 코치입니다.
+
+            다음은 사용자의 이번 주 할일 목록입니다:
+            $taskSummary
+
+            위 정보를 바탕으로 사용자가 한 주를 돌아보고 개선점을 찾을 수 있도록 도와주는 회고 질문 ${questionCount.value}개를 생성해주세요.
+
+            질문 작성 가이드라인:
+            1. 구체적인 할일 내용을 참조하여 개인화된 질문을 만드세요
+            2. 완료된 일에 대해서는 성취감과 학습 포인트를 묻는 질문을 포함하세요
+            3. 미완료 또는 진행 중인 일에 대해서는 장애물과 해결 방안을 묻는 질문을 포함하세요
+            4. 다음 주 계획과 개선에 대한 질문을 포함하세요
+            5. 질문은 한국어로 작성하세요
+            6. 각 질문은 명확하고 구체적이어야 합니다
+
+            JSON 배열 형식으로만 응답하세요.
+        """.trimIndent()
+    }
+
+    private fun buildTaskSummary(tasks: List<Task>): String {
+        val completedTasks = tasks.filter { it.status.name == "DONE" }
+        val inProgressTasks = tasks.filter { it.status.name == "IN_PROGRESS" }
+        val todoTasks = tasks.filter { it.status.name == "TODO" }
+
+        return buildString {
+            if (completedTasks.isNotEmpty()) {
+                appendLine("완료된 할일:")
+                completedTasks.forEach { task ->
+                    appendLine("- ${task.title.value}")
+                }
+            }
+
+            if (inProgressTasks.isNotEmpty()) {
+                appendLine("\n진행 중인 할일:")
+                inProgressTasks.forEach { task ->
+                    appendLine("- ${task.title.value}")
+                }
+            }
+
+            if (todoTasks.isNotEmpty()) {
+                appendLine("\n시작하지 않은 할일:")
+                todoTasks.forEach { task ->
+                    appendLine("- ${task.title.value}")
+                }
+            }
+
+            appendLine("\n총 ${tasks.size}개의 할일 중 ${completedTasks.size}개 완료")
+        }
+    }
+
+    private fun parseQuestionsFromResponse(response: String, expectedCount: Int): List<String> {
+        return try {
+            val questions: List<String> = objectMapper.readValue(
+                response,
+                object : TypeReference<List<String>>() {}
+            )
+            questions.take(expectedCount)
+        } catch (e: Exception) {
+            logger.warn("JSON 파싱 실패, 텍스트 파싱 시도: ${e.message}")
+            parseQuestionsFromText(response, expectedCount)
+        }
+    }
+
+    private fun parseQuestionsFromText(response: String, expectedCount: Int): List<String> {
+        val lines = response.lines()
+            .map { it.trim() }
+            .filter { it.isNotBlank() }
+            .map { line ->
+                line.removePrefix("-")
+                    .removePrefix("•")
+                    .trim()
+                    .let { if (it.matches(Regex("^\\d+\\..*"))) it.substringAfter(".").trim() else it }
+            }
+            .filter { it.endsWith("?") || it.endsWith("?") }
+
+        return lines.take(expectedCount)
+    }
+
+    private fun generateFallbackQuestions(tasks: List<Task>, questionCount: QuestionCount): List<String> {
+        val fallbackQuestions = mutableListOf<String>()
+
+        if (tasks.isNotEmpty()) {
+            val completedTasks = tasks.filter { it.status.name == "DONE" }
+            val inProgressTasks = tasks.filter { it.status.name == "IN_PROGRESS" }
+
+            if (completedTasks.isNotEmpty()) {
+                fallbackQuestions.add("완료한 '${completedTasks.first().title.value}' 작업에서 얻은 가장 큰 배움은 무엇인가요?")
+            }
+            if (inProgressTasks.isNotEmpty()) {
+                fallbackQuestions.add("진행 중인 '${inProgressTasks.first().title.value}' 작업을 완료하기 위해 필요한 것은 무엇인가요?")
+            }
+        }
+
+        val defaultQuestions = listOf(
+            "이번 주 가장 잘한 일은 무엇인가요?",
+            "이번 주 가장 어려웠던 점은 무엇인가요?",
+            "다음 주에 개선하고 싶은 점은 무엇인가요?",
+            "이번 주 배운 점이 있다면 무엇인가요?",
+            "자신에게 칭찬해주고 싶은 점이 있나요?"
+        )
+
+        val remaining = questionCount.value - fallbackQuestions.size
+        if (remaining > 0) {
+            fallbackQuestions.addAll(defaultQuestions.take(remaining))
+        }
+
+        return fallbackQuestions.take(questionCount.value)
+    }
+}

--- a/server/src/main/resources/application.yaml
+++ b/server/src/main/resources/application.yaml
@@ -21,6 +21,12 @@ jwt:
   secret: ${JWT_SECRET:growweek-dev-secret-key-for-jwt-token-generation-256-bits-minimum}
   expiration: 3600000
 
+gemini:
+  api-key: ${GEMINI_API_KEY:}
+  base-url: https://generativelanguage.googleapis.com
+  model: gemini-2.0-flash
+  thinking-level: low
+
 management:
   endpoint:
     health:

--- a/server/src/main/resources/application.yaml
+++ b/server/src/main/resources/application.yaml
@@ -22,9 +22,9 @@ jwt:
   expiration: 3600000
 
 gemini:
-  api-key: ${GEMINI_API_KEY:}
+  api-key: ${GEMINI_API_KEY}
   base-url: https://generativelanguage.googleapis.com
-  model: gemini-2.0-flash
+  model: gemini-3-flash-preview
   thinking-level: low
 
 management:

--- a/server/src/test/kotlin/xyz/robinjoon/growweek/retrospective/infrastructure/external/gemini/GeminiApiDtoTest.kt
+++ b/server/src/test/kotlin/xyz/robinjoon/growweek/retrospective/infrastructure/external/gemini/GeminiApiDtoTest.kt
@@ -1,0 +1,159 @@
+package xyz.robinjoon.growweek.retrospective.infrastructure.external.gemini
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class GeminiApiDtoTest : BehaviorSpec({
+
+    val objectMapper = jacksonObjectMapper()
+
+    Given("GeminiRequest를 생성할 때") {
+
+        When("텍스트 프롬프트로 요청을 생성하면") {
+            val request = GeminiRequest.createTextRequest(
+                prompt = "테스트 프롬프트",
+                thinkingLevel = "low"
+            )
+
+            Then("contents가 올바르게 설정되어야 한다") {
+                request.contents.size shouldBe 1
+                request.contents[0].parts.size shouldBe 1
+                request.contents[0].parts[0].text shouldBe "테스트 프롬프트"
+            }
+
+            Then("generationConfig가 올바르게 설정되어야 한다") {
+                request.generationConfig shouldNotBe null
+                request.generationConfig?.thinkingConfig?.thinkingLevel shouldBe "low"
+                request.generationConfig?.responseMimeType shouldBe "application/json"
+            }
+
+            Then("responseSchema가 올바르게 설정되어야 한다") {
+                request.generationConfig?.responseSchema?.type shouldBe "array"
+                request.generationConfig?.responseSchema?.items?.type shouldBe "string"
+            }
+        }
+
+        When("요청을 JSON으로 직렬화하면") {
+            val request = GeminiRequest.createTextRequest(
+                prompt = "질문 생성",
+                thinkingLevel = "medium"
+            )
+            val json = objectMapper.writeValueAsString(request)
+
+            Then("올바른 JSON 형식으로 변환되어야 한다") {
+                json.contains("\"text\":\"질문 생성\"") shouldBe true
+                json.contains("\"thinkingLevel\":\"medium\"") shouldBe true
+                json.contains("\"responseMimeType\":\"application/json\"") shouldBe true
+            }
+        }
+    }
+
+    Given("GeminiResponse를 파싱할 때") {
+
+        When("정상적인 응답을 파싱하면") {
+            val jsonResponse = """
+                {
+                    "candidates": [
+                        {
+                            "content": {
+                                "parts": [
+                                    {"text": "[\"질문1\", \"질문2\", \"질문3\"]"}
+                                ],
+                                "role": "model"
+                            },
+                            "finishReason": "STOP",
+                            "index": 0
+                        }
+                    ],
+                    "usageMetadata": {
+                        "promptTokenCount": 100,
+                        "candidatesTokenCount": 50,
+                        "totalTokenCount": 150
+                    },
+                    "modelVersion": "gemini-2.0-flash"
+                }
+            """.trimIndent()
+
+            val response = objectMapper.readValue(jsonResponse, GeminiResponse::class.java)
+
+            Then("candidates가 올바르게 파싱되어야 한다") {
+                response.candidates shouldNotBe null
+                response.candidates?.size shouldBe 1
+            }
+
+            Then("텍스트를 추출할 수 있어야 한다") {
+                val text = response.extractText()
+                text shouldBe "[\"질문1\", \"질문2\", \"질문3\"]"
+            }
+
+            Then("usageMetadata가 올바르게 파싱되어야 한다") {
+                response.usageMetadata?.promptTokenCount shouldBe 100
+                response.usageMetadata?.candidatesTokenCount shouldBe 50
+                response.usageMetadata?.totalTokenCount shouldBe 150
+            }
+        }
+
+        When("thinking이 포함된 응답을 파싱하면") {
+            val jsonResponse = """
+                {
+                    "candidates": [
+                        {
+                            "content": {
+                                "parts": [
+                                    {"text": "생각 중...", "thought": true},
+                                    {"text": "[\"실제 답변\"]", "thought": false}
+                                ],
+                                "role": "model"
+                            }
+                        }
+                    ]
+                }
+            """.trimIndent()
+
+            val response = objectMapper.readValue(jsonResponse, GeminiResponse::class.java)
+
+            Then("thinking을 제외한 텍스트만 추출되어야 한다") {
+                val text = response.extractText()
+                text shouldBe "[\"실제 답변\"]"
+            }
+        }
+
+        When("빈 candidates로 응답이 오면") {
+            val jsonResponse = """
+                {
+                    "candidates": []
+                }
+            """.trimIndent()
+
+            val response = objectMapper.readValue(jsonResponse, GeminiResponse::class.java)
+
+            Then("extractText가 null을 반환해야 한다") {
+                response.extractText() shouldBe null
+            }
+        }
+
+        When("에러 응답을 파싱하면") {
+            val jsonResponse = """
+                {
+                    "candidates": null,
+                    "error": {
+                        "code": 400,
+                        "message": "Invalid API key",
+                        "status": "INVALID_ARGUMENT"
+                    }
+                }
+            """.trimIndent()
+
+            val response = objectMapper.readValue(jsonResponse, GeminiResponse::class.java)
+
+            Then("error가 올바르게 파싱되어야 한다") {
+                response.error shouldNotBe null
+                response.error?.code shouldBe 400
+                response.error?.message shouldBe "Invalid API key"
+                response.error?.status shouldBe "INVALID_ARGUMENT"
+            }
+        }
+    }
+})

--- a/server/src/test/kotlin/xyz/robinjoon/growweek/retrospective/infrastructure/external/gemini/GeminiClientIntegrationTest.kt
+++ b/server/src/test/kotlin/xyz/robinjoon/growweek/retrospective/infrastructure/external/gemini/GeminiClientIntegrationTest.kt
@@ -1,0 +1,89 @@
+package xyz.robinjoon.growweek.retrospective.infrastructure.external.gemini
+
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotBeBlank
+
+/**
+ * Gemini API 통합 테스트
+ *
+ * 실제 Gemini API를 호출하여 연동이 정상적으로 동작하는지 확인합니다.
+ * 환경변수 GEMINI_API_KEY가 설정되어 있어야 실행됩니다.
+ *
+ * 주의: thinkingLevel은 gemini-3-flash-preview, gemini-3-pro-preview 모델에서만 지원됩니다.
+ */
+@EnabledIf(GeminiApiKeyCondition::class)
+class GeminiClientIntegrationTest : BehaviorSpec({
+
+    val apiKey = System.getenv("GEMINI_API_KEY") ?: ""
+
+    Given("Gemini API 키가 설정되어 있을 때") {
+
+        When("gemini-3-flash-preview 모델로 텍스트 생성을 요청하면") {
+            val properties = GeminiProperties(
+                apiKey = apiKey,
+                model = "gemini-3-flash-preview",
+                thinkingLevel = "low"
+            )
+            val client = GeminiClient(properties)
+
+            val result = client.generateContent("1 + 1 = ? 숫자만 답해주세요.")
+
+            Then("응답이 반환되어야 한다") {
+                result.shouldNotBeBlank()
+                println("gemini-3-flash-preview 응답: $result")
+            }
+        }
+
+        When("gemini-3-pro-preview 모델로 텍스트 생성을 요청하면") {
+            val properties = GeminiProperties(
+                apiKey = apiKey,
+                model = "gemini-3-pro-preview",
+                thinkingLevel = "low"
+            )
+            val client = GeminiClient(properties)
+
+            val result = client.generateContent("대한민국의 수도는? 도시 이름만 답해주세요.")
+
+            Then("응답이 반환되어야 한다") {
+                result.shouldNotBeBlank()
+                println("gemini-3-pro-preview 응답: $result")
+            }
+        }
+
+        When("JSON 배열 형식으로 질문 생성을 요청하면") {
+            val properties = GeminiProperties(
+                apiKey = apiKey,
+                model = "gemini-3-flash-preview",
+                thinkingLevel = "low"
+            )
+            val client = GeminiClient(properties)
+
+            val prompt = """
+                회고 질문 3개를 생성해주세요.
+                JSON 배열 형식으로만 응답하세요.
+                예시: ["질문1", "질문2", "질문3"]
+            """.trimIndent()
+
+            val result = client.generateContent(prompt)
+
+            Then("JSON 배열 형식의 응답이 반환되어야 한다") {
+                result.shouldNotBeBlank()
+                result.contains("[") shouldBe true
+                result.contains("]") shouldBe true
+                println("질문 생성 응답: $result")
+            }
+        }
+    }
+})
+
+/**
+ * GEMINI_API_KEY 환경변수가 설정되어 있는지 확인하는 조건
+ */
+class GeminiApiKeyCondition : io.kotest.core.annotation.Condition {
+    override fun evaluate(kclass: kotlin.reflect.KClass<out io.kotest.core.spec.Spec>): Boolean {
+        val apiKey = System.getenv("GEMINI_API_KEY")
+        return !apiKey.isNullOrBlank()
+    }
+}

--- a/server/src/test/kotlin/xyz/robinjoon/growweek/retrospective/infrastructure/external/gemini/GeminiClientTest.kt
+++ b/server/src/test/kotlin/xyz/robinjoon/growweek/retrospective/infrastructure/external/gemini/GeminiClientTest.kt
@@ -1,0 +1,196 @@
+package xyz.robinjoon.growweek.retrospective.infrastructure.external.gemini
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+class GeminiClientTest : BehaviorSpec({
+
+    Given("GeminiProperties가 올바르게 설정되었을 때") {
+
+        When("Properties를 생성하면") {
+            val properties = GeminiProperties(
+                apiKey = "test-api-key",
+                baseUrl = "https://generativelanguage.googleapis.com",
+                model = "gemini-2.0-flash",
+                thinkingLevel = "low"
+            )
+
+            Then("모든 값이 올바르게 설정되어야 한다") {
+                properties.apiKey shouldBe "test-api-key"
+                properties.baseUrl shouldBe "https://generativelanguage.googleapis.com"
+                properties.model shouldBe "gemini-2.0-flash"
+                properties.thinkingLevel shouldBe "low"
+            }
+        }
+
+        When("기본값을 사용하면") {
+            val properties = GeminiProperties(
+                apiKey = "test-api-key"
+            )
+
+            Then("기본값이 적용되어야 한다") {
+                properties.baseUrl shouldBe "https://generativelanguage.googleapis.com"
+                properties.model shouldBe "gemini-2.0-flash"
+                properties.thinkingLevel shouldBe "low"
+            }
+        }
+    }
+
+    Given("GeminiApiException이 발생했을 때") {
+
+        When("에러 코드와 메시지가 있으면") {
+            val exception = GeminiApiException(
+                message = "API 키가 유효하지 않습니다",
+                errorCode = 401
+            )
+
+            Then("메시지와 코드가 올바르게 설정되어야 한다") {
+                exception.message shouldBe "API 키가 유효하지 않습니다"
+                exception.errorCode shouldBe 401
+            }
+        }
+
+        When("원인 예외가 있으면") {
+            val cause = RuntimeException("원인")
+            val exception = GeminiApiException(
+                message = "API 호출 실패",
+                cause = cause
+            )
+
+            Then("원인이 올바르게 설정되어야 한다") {
+                exception.cause shouldBe cause
+            }
+        }
+    }
+
+    Given("GeminiRequest를 생성할 때") {
+
+        When("createTextRequest로 요청을 생성하면") {
+            val request = GeminiRequest.createTextRequest(
+                prompt = "테스트 프롬프트입니다",
+                thinkingLevel = "medium"
+            )
+
+            Then("contents에 프롬프트가 포함되어야 한다") {
+                request.contents.size shouldBe 1
+                request.contents[0].parts[0].text shouldBe "테스트 프롬프트입니다"
+            }
+
+            Then("generationConfig에 thinkingLevel이 설정되어야 한다") {
+                request.generationConfig?.thinkingConfig?.thinkingLevel shouldBe "medium"
+            }
+
+            Then("JSON 스키마가 배열 형식으로 설정되어야 한다") {
+                request.generationConfig?.responseSchema?.type shouldBe "array"
+                request.generationConfig?.responseSchema?.items?.type shouldBe "string"
+            }
+        }
+    }
+
+    Given("GeminiResponse에서 텍스트를 추출할 때") {
+
+        When("정상적인 응답이면") {
+            val response = GeminiResponse(
+                candidates = listOf(
+                    GeminiResponse.Candidate(
+                        content = GeminiResponse.Content(
+                            parts = listOf(
+                                GeminiResponse.Part(text = "답변 내용입니다")
+                            ),
+                            role = "model"
+                        ),
+                        finishReason = "STOP"
+                    )
+                )
+            )
+
+            Then("텍스트가 추출되어야 한다") {
+                response.extractText() shouldBe "답변 내용입니다"
+            }
+        }
+
+        When("여러 part가 있으면") {
+            val response = GeminiResponse(
+                candidates = listOf(
+                    GeminiResponse.Candidate(
+                        content = GeminiResponse.Content(
+                            parts = listOf(
+                                GeminiResponse.Part(text = "첫 번째 "),
+                                GeminiResponse.Part(text = "두 번째")
+                            ),
+                            role = "model"
+                        )
+                    )
+                )
+            )
+
+            Then("모든 텍스트가 합쳐져야 한다") {
+                response.extractText() shouldBe "첫 번째 두 번째"
+            }
+        }
+
+        When("thought가 true인 part가 포함되어 있으면") {
+            val response = GeminiResponse(
+                candidates = listOf(
+                    GeminiResponse.Candidate(
+                        content = GeminiResponse.Content(
+                            parts = listOf(
+                                GeminiResponse.Part(text = "생각...", thought = true),
+                                GeminiResponse.Part(text = "실제 답변", thought = false)
+                            ),
+                            role = "model"
+                        )
+                    )
+                )
+            )
+
+            Then("thought를 제외한 텍스트만 추출되어야 한다") {
+                response.extractText() shouldBe "실제 답변"
+            }
+        }
+
+        When("candidates가 null이면") {
+            val response = GeminiResponse(candidates = null)
+
+            Then("null이 반환되어야 한다") {
+                response.extractText() shouldBe null
+            }
+        }
+
+        When("candidates가 비어있으면") {
+            val response = GeminiResponse(candidates = emptyList())
+
+            Then("null이 반환되어야 한다") {
+                response.extractText() shouldBe null
+            }
+        }
+
+        When("content가 null이면") {
+            val response = GeminiResponse(
+                candidates = listOf(
+                    GeminiResponse.Candidate(content = null)
+                )
+            )
+
+            Then("null이 반환되어야 한다") {
+                response.extractText() shouldBe null
+            }
+        }
+
+        When("parts가 null이면") {
+            val response = GeminiResponse(
+                candidates = listOf(
+                    GeminiResponse.Candidate(
+                        content = GeminiResponse.Content(parts = null)
+                    )
+                )
+            )
+
+            Then("null이 반환되어야 한다") {
+                response.extractText() shouldBe null
+            }
+        }
+    }
+})

--- a/server/src/test/kotlin/xyz/robinjoon/growweek/retrospective/infrastructure/external/gemini/GeminiClientTest.kt
+++ b/server/src/test/kotlin/xyz/robinjoon/growweek/retrospective/infrastructure/external/gemini/GeminiClientTest.kt
@@ -13,14 +13,14 @@ class GeminiClientTest : BehaviorSpec({
             val properties = GeminiProperties(
                 apiKey = "test-api-key",
                 baseUrl = "https://generativelanguage.googleapis.com",
-                model = "gemini-2.0-flash",
+                model = "gemini-3-flash-preview",
                 thinkingLevel = "low"
             )
 
             Then("모든 값이 올바르게 설정되어야 한다") {
                 properties.apiKey shouldBe "test-api-key"
                 properties.baseUrl shouldBe "https://generativelanguage.googleapis.com"
-                properties.model shouldBe "gemini-2.0-flash"
+                properties.model shouldBe "gemini-3-flash-preview"
                 properties.thinkingLevel shouldBe "low"
             }
         }

--- a/server/src/test/kotlin/xyz/robinjoon/growweek/retrospective/infrastructure/external/gemini/GeminiQuestionGenerationServiceTest.kt
+++ b/server/src/test/kotlin/xyz/robinjoon/growweek/retrospective/infrastructure/external/gemini/GeminiQuestionGenerationServiceTest.kt
@@ -1,0 +1,198 @@
+package xyz.robinjoon.growweek.retrospective.infrastructure.external.gemini
+
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import xyz.robinjoon.growweek.common.domain.MemberId
+import xyz.robinjoon.growweek.common.domain.SensitivityLevel
+import xyz.robinjoon.growweek.common.domain.TaskId
+import xyz.robinjoon.growweek.retrospective.domain.model.QuestionCount
+import xyz.robinjoon.growweek.task.domain.model.*
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class GeminiQuestionGenerationServiceTest : BehaviorSpec({
+
+    isolationMode = IsolationMode.InstancePerLeaf
+
+    val geminiClient = mockk<GeminiClient>()
+    val service = GeminiQuestionGenerationService(geminiClient)
+
+    Given("질문 생성 요청이 왔을 때") {
+
+        val tasks = listOf(
+            createTask(TaskId(1L), "프로젝트 기획서 작성", TaskStatus.DONE),
+            createTask(TaskId(2L), "코드 리뷰", TaskStatus.IN_PROGRESS),
+            createTask(TaskId(3L), "회의 준비", TaskStatus.TODO)
+        )
+        val questionCount = QuestionCount(3)
+
+        When("Gemini API가 정상 응답을 반환하면") {
+            val apiResponse = """["이번 주 프로젝트 기획서 작성에서 가장 중요하게 고려한 점은 무엇인가요?", "코드 리뷰를 진행하면서 발견한 개선점이 있나요?", "다음 주 계획을 세울 때 이번 주 경험을 어떻게 반영하시겠어요?"]"""
+
+            every { geminiClient.generateContent(any()) } returns apiResponse
+
+            val result = runBlocking { service.generateQuestions(tasks, questionCount) }
+
+            Then("3개의 질문이 생성되어야 한다") {
+                result.size shouldBe 3
+            }
+
+            Then("JSON 배열이 파싱되어야 한다") {
+                result[0] shouldBe "이번 주 프로젝트 기획서 작성에서 가장 중요하게 고려한 점은 무엇인가요?"
+            }
+
+            Then("GeminiClient가 호출되어야 한다") {
+                verify { geminiClient.generateContent(any()) }
+            }
+        }
+
+        When("요청 개수보다 많은 질문이 반환되면") {
+            val apiResponse = """["질문1", "질문2", "질문3", "질문4", "질문5"]"""
+
+            every { geminiClient.generateContent(any()) } returns apiResponse
+
+            val result = runBlocking { service.generateQuestions(tasks, QuestionCount(3)) }
+
+            Then("요청한 개수만큼만 반환되어야 한다") {
+                result.size shouldBe 3
+            }
+        }
+    }
+
+    Given("Gemini API 호출이 실패했을 때") {
+
+        val tasks = listOf(
+            createTask(TaskId(1L), "완료된 작업", TaskStatus.DONE)
+        )
+        val questionCount = QuestionCount(3)
+
+        When("GeminiApiException이 발생하면") {
+            every { geminiClient.generateContent(any()) } throws GeminiApiException("API 호출 실패")
+
+            val result = runBlocking { service.generateQuestions(tasks, questionCount) }
+
+            Then("fallback 질문이 반환되어야 한다") {
+                result.size shouldBe 3
+            }
+
+            Then("할일 기반 질문이 포함되어야 한다") {
+                result.any { it.contains("완료된 작업") } shouldBe true
+            }
+        }
+
+        When("일반 예외가 발생하면") {
+            every { geminiClient.generateContent(any()) } throws RuntimeException("알 수 없는 오류")
+
+            val result = runBlocking { service.generateQuestions(tasks, questionCount) }
+
+            Then("fallback 질문이 반환되어야 한다") {
+                result.size shouldBe 3
+            }
+        }
+    }
+
+    Given("할일 목록이 비어있을 때") {
+
+        val emptyTasks = emptyList<Task>()
+        val questionCount = QuestionCount(3)
+
+        When("질문 생성을 요청하면") {
+            val apiResponse = """["이번 주 목표를 달성하기 어려웠던 이유는 무엇인가요?", "다음 주에 집중하고 싶은 영역은?", "업무 외적으로 배운 점이 있나요?"]"""
+
+            every { geminiClient.generateContent(any()) } returns apiResponse
+
+            val result = runBlocking { service.generateQuestions(emptyTasks, questionCount) }
+
+            Then("질문이 생성되어야 한다") {
+                result.size shouldBe 3
+            }
+        }
+    }
+
+    Given("다양한 상태의 할일이 있을 때") {
+
+        val tasks = listOf(
+            createTask(TaskId(1L), "완료된 작업 A", TaskStatus.DONE),
+            createTask(TaskId(2L), "완료된 작업 B", TaskStatus.DONE),
+            createTask(TaskId(3L), "진행 중인 작업", TaskStatus.IN_PROGRESS),
+            createTask(TaskId(4L), "시작 전 작업", TaskStatus.TODO)
+        )
+
+        When("프롬프트를 생성하면") {
+            var capturedPrompt: String? = null
+            every { geminiClient.generateContent(any()) } answers {
+                capturedPrompt = firstArg()
+                """["질문1", "질문2", "질문3"]"""
+            }
+
+            runBlocking { service.generateQuestions(tasks, QuestionCount(3)) }
+
+            Then("완료된 할일 정보가 프롬프트에 포함되어야 한다") {
+                capturedPrompt shouldContainSubstring "완료된 할일"
+                capturedPrompt shouldContainSubstring "완료된 작업 A"
+            }
+
+            Then("진행 중인 할일 정보가 프롬프트에 포함되어야 한다") {
+                capturedPrompt shouldContainSubstring "진행 중인 할일"
+                capturedPrompt shouldContainSubstring "진행 중인 작업"
+            }
+
+            Then("시작하지 않은 할일 정보가 프롬프트에 포함되어야 한다") {
+                capturedPrompt shouldContainSubstring "시작하지 않은 할일"
+                capturedPrompt shouldContainSubstring "시작 전 작업"
+            }
+        }
+    }
+
+    Given("JSON이 아닌 텍스트 응답이 왔을 때") {
+
+        val tasks = listOf(createTask(TaskId(1L), "작업", TaskStatus.DONE))
+
+        When("번호가 붙은 질문 목록이 반환되면") {
+            val textResponse = """
+                1. 이번 주 가장 잘한 일은 무엇인가요?
+                2. 어려웠던 점은 무엇인가요?
+                3. 다음 주 계획은?
+            """.trimIndent()
+
+            every { geminiClient.generateContent(any()) } returns textResponse
+
+            val result = runBlocking { service.generateQuestions(tasks, QuestionCount(3)) }
+
+            Then("텍스트 파싱으로 질문이 추출되어야 한다") {
+                result.isNotEmpty() shouldBe true
+            }
+        }
+    }
+})
+
+private fun createTask(
+    taskId: TaskId,
+    title: String,
+    status: TaskStatus
+): Task {
+    val now = LocalDateTime.now()
+    return Task(
+        id = taskId,
+        memberId = MemberId(1L),
+        title = TaskTitle(title),
+        description = TaskDescription("설명"),
+        status = status,
+        sensitivityLevel = SensitivityLevel.NONE,
+        priority = Priority(1),
+        period = TaskPeriod(LocalDate.now().minusDays(7), LocalDate.now()),
+        createdAt = now,
+        updatedAt = now,
+        retrospectiveId = null
+    )
+}
+
+private infix fun String?.shouldContainSubstring(substring: String) {
+    this?.contains(substring) shouldBe true
+}


### PR DESCRIPTION
## Summary
- Google Gemini API를 활용한 회고 질문 생성 인프라 레이어 구현
- RestClient 기반 HTTP 클라이언트로 Gemini REST API 연동
- 환경변수 `GEMINI_API_KEY` 설정 시 자동 활성화 (기존 Mock 서비스 대체)

## Changes
- `GeminiProperties`: API 설정 프로퍼티 (`api-key`, `base-url`, `model`, `thinking-level`)
- `GeminiApiDto`: Gemini REST API 요청/응답 DTO
- `GeminiClient`: RestClient 기반 HTTP 클라이언트
- `GeminiQuestionGenerationService`: `QuestionGenerationService` 구현체 (`@Primary`, `@ConditionalOnProperty`)
- `GeminiConfig`: 설정 활성화 클래스
- `application.yaml`: Gemini 설정 추가

## Test plan
- [x] GeminiApiDtoTest: 요청/응답 DTO 직렬화/역직렬화 테스트
- [x] GeminiClientTest: Properties, Exception, DTO 생성 테스트
- [x] GeminiQuestionGenerationServiceTest: 질문 생성 서비스 로직 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)