### PR TITLE
fix(ci): GitHub Actions DNS 문제 해결을 위해 Google DNS 사용

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -19,6 +19,12 @@ jobs:
         working-directory: server
 
     steps:
+      - name: Configure DNS to use Google DNS
+        working-directory: /
+        run: |
+          sudo sed -i 's/nameserver.*/nameserver 8.8.8.8/' /etc/resolv.conf
+          echo "nameserver 8.8.4.4" | sudo tee -a /etc/resolv.conf
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -58,6 +64,12 @@ jobs:
       image-tag: ${{ steps.meta.outputs.tag }}
 
     steps:
+      - name: Configure DNS to use Google DNS
+        working-directory: /
+        run: |
+          sudo sed -i 's/nameserver.*/nameserver 8.8.8.8/' /etc/resolv.conf
+          echo "nameserver 8.8.4.4" | sudo tee -a /etc/resolv.conf
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -115,6 +127,11 @@ jobs:
     needs: build-and-push
 
     steps:
+      - name: Configure DNS to use Google DNS
+        run: |
+          sudo sed -i 's/nameserver.*/nameserver 8.8.8.8/' /etc/resolv.conf
+          echo "nameserver 8.8.4.4" | sudo tee -a /etc/resolv.conf
+
       - name: Checkout Helm repository
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- GitHub Actions 러너에서 DNS 조회 실패 문제 해결
- 각 job(test, build-and-push, update-helm)의 첫 번째 step에서 Google DNS(8.8.8.8, 8.8.4.4) 설정
- Harbor 레지스트리 등 커스텀 도메인 resolve 문제 해결

## Test plan
- [ ] develop 브랜치에 머지 후 워크플로우가 정상적으로 실행되는지 확인
- [ ] Harbor 레지스트리 접근이 정상적으로 되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)