### PR TITLE
ci: dev 배포 워크플로우에 수동 트리거 추가

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -6,6 +6,7 @@ on:
       - develop
     paths:
       - 'server/**'
+  workflow_dispatch:
 
 env:
   HARBOR_REGISTRY: harbor.homelab.robinjoon.xyz


### PR DESCRIPTION
## Summary
- dev 배포 워크플로우에 `workflow_dispatch` 이벤트 추가
- GitHub Actions UI에서 수동으로 배포를 트리거할 수 있도록 개선

## Test plan
- [ ] GitHub Actions 탭에서 "Run workflow" 버튼 확인
- [ ] 수동 트리거로 워크플로우 실행 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)