### PR TITLE
회고 작성 규칙 수정

### DIFF
--- a/server/src/main/kotlin/xyz/robinjoon/growweek/retrospective/domain/model/RetrospectivePeriod.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/retrospective/domain/model/RetrospectivePeriod.kt
@@ -15,11 +15,12 @@ data class RetrospectivePeriod(
 
     /**
      * 회고 작성 가능 여부 확인
-     * 다음 주 월요일 0시까지 작성 가능
+     * 종료일 2일 전(금요일)부터 다음 주 월요일 0시 전까지 작성 가능
      */
     fun isWritable(currentDate: LocalDate = LocalDate.now()): Boolean {
-        val nextMonday = calculateNextMonday(endDate)
-        return !currentDate.isAfter(nextMonday)
+        val writableStartDate = endDate.minusDays(DAYS_BEFORE_END_DATE_TO_START_WRITING)
+        val writableEndDate = calculateNextMonday(endDate)
+        return !currentDate.isBefore(writableStartDate) && currentDate.isBefore(writableEndDate)
     }
 
     private fun calculateNextMonday(date: LocalDate): LocalDate {
@@ -29,5 +30,9 @@ data class RetrospectivePeriod(
         } else {
             date.plusDays(daysUntilMonday.toLong())
         }
+    }
+
+    companion object {
+        private const val DAYS_BEFORE_END_DATE_TO_START_WRITING = 2L
     }
 }

--- a/server/src/test/kotlin/xyz/robinjoon/growweek/retrospective/domain/model/RetrospectivePeriodTest.kt
+++ b/server/src/test/kotlin/xyz/robinjoon/growweek/retrospective/domain/model/RetrospectivePeriodTest.kt
@@ -43,56 +43,52 @@ class RetrospectivePeriodTest :
             }
         }
 
-        Given("회고 작성 가능 여부를 확인할 때") {
+        Given("회고 작성 가능 여부를 확인할 때 - 종료일 2일 전(금요일)부터 다음 월요일 0시 전까지 작성 가능") {
 
-            When("종료일이 월요일이고 현재 날짜가 다음 주 월요일 이전인 경우") {
-                // 종료일: 2025-01-06 (월요일)
-                // 다음 주 월요일: 2025-01-13
+            // 기준: 종료일 2025-01-12 (일요일)
+            // 작성 가능 시작일: 2025-01-10 (금요일, 종료일 2일 전)
+            // 작성 가능 종료일: 2025-01-13 (월요일) 0시 전까지
+
+            When("현재 날짜가 종료일 3일 전(목요일)인 경우") {
                 val period =
                     RetrospectivePeriod(
                         LocalDate.of(2025, 1, 6),
+                        LocalDate.of(2025, 1, 12),
+                    )
+                val currentDate = LocalDate.of(2025, 1, 9) // 목요일
+
+                Then("작성 불가능해야 한다 (아직 작성 기간 시작 전)") {
+                    period.isWritable(currentDate) shouldBe false
+                }
+            }
+
+            When("현재 날짜가 종료일 2일 전(금요일)인 경우") {
+                val period =
+                    RetrospectivePeriod(
                         LocalDate.of(2025, 1, 6),
+                        LocalDate.of(2025, 1, 12),
                     )
                 val currentDate = LocalDate.of(2025, 1, 10) // 금요일
+
+                Then("작성 가능해야 한다 (작성 기간 시작)") {
+                    period.isWritable(currentDate) shouldBe true
+                }
+            }
+
+            When("현재 날짜가 종료일 1일 전(토요일)인 경우") {
+                val period =
+                    RetrospectivePeriod(
+                        LocalDate.of(2025, 1, 6),
+                        LocalDate.of(2025, 1, 12),
+                    )
+                val currentDate = LocalDate.of(2025, 1, 11) // 토요일
 
                 Then("작성 가능해야 한다") {
                     period.isWritable(currentDate) shouldBe true
                 }
             }
 
-            When("종료일이 월요일이고 현재 날짜가 다음 주 월요일인 경우") {
-                // 종료일: 2025-01-06 (월요일)
-                // 다음 주 월요일: 2025-01-13
-                val period =
-                    RetrospectivePeriod(
-                        LocalDate.of(2025, 1, 6),
-                        LocalDate.of(2025, 1, 6),
-                    )
-                val currentDate = LocalDate.of(2025, 1, 13) // 다음 주 월요일
-
-                Then("작성 가능해야 한다 (월요일 0시까지)") {
-                    period.isWritable(currentDate) shouldBe true
-                }
-            }
-
-            When("종료일이 월요일이고 현재 날짜가 다음 주 월요일 이후인 경우") {
-                // 종료일: 2025-01-06 (월요일)
-                // 다음 주 월요일: 2025-01-13
-                val period =
-                    RetrospectivePeriod(
-                        LocalDate.of(2025, 1, 6),
-                        LocalDate.of(2025, 1, 6),
-                    )
-                val currentDate = LocalDate.of(2025, 1, 14) // 화요일
-
-                Then("작성 불가능해야 한다") {
-                    period.isWritable(currentDate) shouldBe false
-                }
-            }
-
-            When("종료일이 일요일이고 현재 날짜가 다음 날(월요일) 이전인 경우") {
-                // 종료일: 2025-01-12 (일요일)
-                // 다음 주 월요일: 2025-01-13
+            When("현재 날짜가 종료일 당일(일요일)인 경우") {
                 val period =
                     RetrospectivePeriod(
                         LocalDate.of(2025, 1, 6),
@@ -105,9 +101,7 @@ class RetrospectivePeriodTest :
                 }
             }
 
-            When("종료일이 일요일이고 현재 날짜가 다음 날(월요일)인 경우") {
-                // 종료일: 2025-01-12 (일요일)
-                // 다음 주 월요일: 2025-01-13
+            When("현재 날짜가 다음 월요일인 경우") {
                 val period =
                     RetrospectivePeriod(
                         LocalDate.of(2025, 1, 6),
@@ -115,14 +109,12 @@ class RetrospectivePeriodTest :
                     )
                 val currentDate = LocalDate.of(2025, 1, 13) // 월요일
 
-                Then("작성 가능해야 한다 (월요일 0시까지)") {
-                    period.isWritable(currentDate) shouldBe true
+                Then("작성 불가능해야 한다 (월요일 0시부터 작성 불가)") {
+                    period.isWritable(currentDate) shouldBe false
                 }
             }
 
-            When("종료일이 일요일이고 현재 날짜가 다음 날(월요일) 이후인 경우") {
-                // 종료일: 2025-01-12 (일요일)
-                // 다음 주 월요일: 2025-01-13
+            When("현재 날짜가 다음 월요일 이후(화요일)인 경우") {
                 val period =
                     RetrospectivePeriod(
                         LocalDate.of(2025, 1, 6),
@@ -134,48 +126,62 @@ class RetrospectivePeriodTest :
                     period.isWritable(currentDate) shouldBe false
                 }
             }
+        }
 
-            When("종료일이 수요일이고 현재 날짜가 다음 주 월요일 이전인 경우") {
-                // 종료일: 2025-01-08 (수요일)
-                // 다음 주 월요일: 2025-01-13
+        Given("종료일이 월요일인 경우 회고 작성 가능 여부를 확인할 때") {
+
+            // 기준: 종료일 2025-01-06 (월요일)
+            // 작성 가능 시작일: 2025-01-04 (토요일, 종료일 2일 전)
+            // 작성 가능 종료일: 2025-01-13 (다음 월요일) 0시 전까지
+
+            When("현재 날짜가 종료일 3일 전(금요일)인 경우") {
                 val period =
                     RetrospectivePeriod(
                         LocalDate.of(2025, 1, 6),
-                        LocalDate.of(2025, 1, 8),
+                        LocalDate.of(2025, 1, 6),
                     )
-                val currentDate = LocalDate.of(2025, 1, 10) // 금요일
+                val currentDate = LocalDate.of(2025, 1, 3) // 금요일
+
+                Then("작성 불가능해야 한다 (아직 작성 기간 시작 전)") {
+                    period.isWritable(currentDate) shouldBe false
+                }
+            }
+
+            When("현재 날짜가 종료일 2일 전(토요일)인 경우") {
+                val period =
+                    RetrospectivePeriod(
+                        LocalDate.of(2025, 1, 6),
+                        LocalDate.of(2025, 1, 6),
+                    )
+                val currentDate = LocalDate.of(2025, 1, 4) // 토요일
+
+                Then("작성 가능해야 한다 (작성 기간 시작)") {
+                    period.isWritable(currentDate) shouldBe true
+                }
+            }
+
+            When("현재 날짜가 종료일 당일(월요일)인 경우") {
+                val period =
+                    RetrospectivePeriod(
+                        LocalDate.of(2025, 1, 6),
+                        LocalDate.of(2025, 1, 6),
+                    )
+                val currentDate = LocalDate.of(2025, 1, 6) // 월요일
 
                 Then("작성 가능해야 한다") {
                     period.isWritable(currentDate) shouldBe true
                 }
             }
 
-            When("종료일이 수요일이고 현재 날짜가 다음 주 월요일인 경우") {
-                // 종료일: 2025-01-08 (수요일)
-                // 다음 주 월요일: 2025-01-13
+            When("현재 날짜가 다음 주 월요일인 경우") {
                 val period =
                     RetrospectivePeriod(
                         LocalDate.of(2025, 1, 6),
-                        LocalDate.of(2025, 1, 8),
-                    )
-                val currentDate = LocalDate.of(2025, 1, 13) // 월요일
-
-                Then("작성 가능해야 한다") {
-                    period.isWritable(currentDate) shouldBe true
-                }
-            }
-
-            When("종료일이 수요일이고 현재 날짜가 다음 주 화요일인 경우") {
-                // 종료일: 2025-01-08 (수요일)
-                // 다음 주 월요일: 2025-01-13
-                val period =
-                    RetrospectivePeriod(
                         LocalDate.of(2025, 1, 6),
-                        LocalDate.of(2025, 1, 8),
                     )
-                val currentDate = LocalDate.of(2025, 1, 14) // 화요일
+                val currentDate = LocalDate.of(2025, 1, 13) // 다음 주 월요일
 
-                Then("작성 불가능해야 한다") {
+                Then("작성 불가능해야 한다 (월요일 0시부터 작성 불가)") {
                     period.isWritable(currentDate) shouldBe false
                 }
             }

--- a/server/src/test/kotlin/xyz/robinjoon/growweek/retrospective/domain/model/RetrospectiveTest.kt
+++ b/server/src/test/kotlin/xyz/robinjoon/growweek/retrospective/domain/model/RetrospectiveTest.kt
@@ -18,7 +18,6 @@ class RetrospectiveTest :
                 val retrospective =
                     createRetrospective(
                         status = RetrospectiveStatus.TODO,
-                        endDate = LocalDate.now().plusDays(7),
                     )
 
                 Then("작성 가능해야 한다") {
@@ -30,7 +29,6 @@ class RetrospectiveTest :
                 val retrospective =
                     createRetrospective(
                         status = RetrospectiveStatus.IN_PROGRESS,
-                        endDate = LocalDate.now().plusDays(7),
                     )
 
                 Then("작성 가능해야 한다") {
@@ -42,7 +40,6 @@ class RetrospectiveTest :
                 val retrospective =
                     createRetrospective(
                         status = RetrospectiveStatus.AFTER_GENERATE_QUESTION,
-                        endDate = LocalDate.now().plusDays(7),
                     )
 
                 Then("작성 가능해야 한다") {
@@ -54,7 +51,6 @@ class RetrospectiveTest :
                 val retrospective =
                     createRetrospective(
                         status = RetrospectiveStatus.DONE,
-                        endDate = LocalDate.now().plusDays(7),
                     )
 
                 Then("작성 불가능해야 한다") {
@@ -172,7 +168,6 @@ class RetrospectiveTest :
                 val retrospective =
                     createRetrospective(
                         status = RetrospectiveStatus.AFTER_GENERATE_QUESTION,
-                        endDate = LocalDate.now().plusDays(7),
                         questions = questions,
                     )
 
@@ -188,7 +183,6 @@ class RetrospectiveTest :
                 val retrospective =
                     createRetrospective(
                         status = RetrospectiveStatus.IN_PROGRESS,
-                        endDate = LocalDate.now().plusDays(7),
                         questions = questions,
                         answers =
                             mapOf(
@@ -207,7 +201,6 @@ class RetrospectiveTest :
                 val retrospective =
                     createRetrospective(
                         status = RetrospectiveStatus.AFTER_GENERATE_QUESTION,
-                        endDate = LocalDate.now().plusDays(7),
                         questions = questions,
                     )
 
@@ -221,7 +214,6 @@ class RetrospectiveTest :
                 val retrospective =
                     createRetrospective(
                         status = RetrospectiveStatus.AFTER_GENERATE_QUESTION,
-                        endDate = LocalDate.now().plusDays(7),
                         questions = questions,
                     )
 
@@ -236,7 +228,6 @@ class RetrospectiveTest :
                 val retrospective =
                     createRetrospective(
                         status = RetrospectiveStatus.AFTER_GENERATE_QUESTION,
-                        endDate = LocalDate.now().plusDays(7),
                         questions = questions,
                     )
 
@@ -250,7 +241,6 @@ class RetrospectiveTest :
                 val retrospective =
                     createRetrospective(
                         status = RetrospectiveStatus.IN_PROGRESS,
-                        endDate = LocalDate.now().plusDays(7),
                         questions = questions,
                         answers =
                             mapOf(
@@ -268,7 +258,6 @@ class RetrospectiveTest :
                 val retrospective =
                     createRetrospective(
                         status = RetrospectiveStatus.AFTER_GENERATE_QUESTION,
-                        endDate = LocalDate.now().plusDays(7),
                         questions = questions,
                     )
 
@@ -298,7 +287,6 @@ class RetrospectiveTest :
                 val retrospective =
                     createRetrospective(
                         status = RetrospectiveStatus.DONE,
-                        endDate = LocalDate.now().plusDays(7),
                         questions = questions,
                     )
 
@@ -316,7 +304,6 @@ class RetrospectiveTest :
                 val retrospective =
                     createRetrospective(
                         status = RetrospectiveStatus.IN_PROGRESS,
-                        endDate = LocalDate.now().plusDays(7),
                     )
                 val notes = AdditionalNotes("이번 주는 정말 바빴습니다.")
 
@@ -345,7 +332,6 @@ class RetrospectiveTest :
                 val retrospective =
                     createRetrospective(
                         status = RetrospectiveStatus.DONE,
-                        endDate = LocalDate.now().plusDays(7),
                     )
                 val notes = AdditionalNotes("완료된 회고")
 
@@ -412,7 +398,7 @@ class RetrospectiveTest :
 
 private fun createRetrospective(
     status: RetrospectiveStatus = RetrospectiveStatus.TODO,
-    endDate: LocalDate = LocalDate.now().plusDays(7),
+    endDate: LocalDate = LocalDate.now(), // 종료일 2일 전부터 작성 가능하므로 현재 날짜로 설정
     questionCount: QuestionCount = QuestionCount.DEFAULT,
     questions: List<Question> = emptyList(),
     answers: Map<QuestionId, Answer> = emptyMap(),


### PR DESCRIPTION
## Summary

- 회고 작성 기간 규칙 수정: 종료일 2일 전(금요일)부터 다음 월요일 0시 전까지 작성 가능
- 기존에는 기간 시작 제한이 없었고, 월요일 당일까지 작성이 가능했음

## 변경된 회고 작성 기간

| 구분 | 변경 전 | 변경 후 |
|------|---------|---------|
| 시작 | 제한 없음 | 종료일 2일 전(금요일)부터 |
| 종료 | 다음 월요일 포함 | 다음 월요일 0시 전까지 (월요일 불가) |



## 현재 동작 방식

### 회고 완료 조건
| 조건 | 허용 여부 |
|------|----------|
| 모든 질문에 답변 후 완료 | ✅ |
| 일부 질문에만 답변 후 완료 | ✅ |
| 답변 0개로 완료 | ❌ (최소 1개 필요) |

### 기간 만료 시 동작
| 상태 | 답변 작성 | 완료 처리 |
|------|----------|----------|
| AFTER_GENERATE_QUESTION | ❌ | ❌ |
| IN_PROGRESS | ❌ | ✅ |

## TODO (향후 작업)

- [ ] 기간 만료 회고 자동 완료 처리 스케줄러 구현
  - 월요일 0시에 `IN_PROGRESS` → `DONE` 자동 전환
  - `AFTER_GENERATE_QUESTION` 상태 처리 방안 결정 필요

## Test plan

- [x] RetrospectivePeriodTest - 작성 기간 검증 테스트 통과
- [x] RetrospectiveTest - 회고 도메인 테스트 통과
