### PR TITLE
fix(task): 회고가 완료된 기간에 할일 추가/수정 방지

### DIFF
--- a/docs/completed-retrospective-period-validation.md
+++ b/docs/completed-retrospective-period-validation.md
@@ -1,0 +1,282 @@
+# 회고 완료 기간 검증 기능 구현
+
+## 1. 문제 정의
+
+### 1.1 발견된 버그
+
+회고가 완료된 주차에 할일을 추가하거나 수정할 수 있는 버그가 발견되었습니다.
+
+**기대 동작:**
+- 회고가 완료된 기간에는 할일을 추가할 수 없어야 함
+- 회고가 완료된 기간의 할일은 수정할 수 없어야 함
+
+**실제 동작:**
+- 회고 완료 여부와 관계없이 할일 추가/수정이 가능했음
+
+### 1.2 근본 원인 분석
+
+버그의 원인은 두 가지였습니다:
+
+#### 원인 1: CreateTaskService의 검증 로직 부재
+
+`CreateTaskService`에서 할일 생성 시 해당 기간에 완료된 회고가 있는지 검증하지 않았습니다.
+
+```kotlin
+// 기존 코드 - 검증 없이 바로 저장
+override fun execute(command: TaskApplicationCommand.CreateTask): TaskDto {
+    val domainCommand = TaskCommand.CreateTask(...)
+    val savedTasks = taskRepository.saveAll(listOf(domainCommand))
+    return TaskDto.from(savedTasks.first())
+}
+```
+
+#### 원인 2: ExposedTaskRepository의 TODO 미구현
+
+`ExposedTaskRepository`에서 Task 수정 시 `retrospectiveDate`를 조회하는 로직이 TODO로 남아있어 항상 `null`을 반환했습니다. 이로 인해 도메인 모델(`Task.kt`)의 `validateModification()` 검증이 우회되었습니다.
+
+```kotlin
+// 기존 코드 - TODO로 인해 항상 null 반환
+val retrospectiveDate = existingTask.retrospectiveId?.let { retroId ->
+    // TODO: CompletedRetrospectivePeriodRepository를 사용하여 조회
+    null
+}
+```
+
+## 2. 해결 방안
+
+### 2.1 아키텍처 제약 사항
+
+프로젝트는 DDD(Domain-Driven Design)와 Clean Architecture를 따르며, 다음과 같은 제약이 있습니다:
+
+- **Bounded Context 분리**: Task BC에서 Retrospective BC를 직접 참조할 수 없음
+- **도메인 이벤트 활용**: BC 간 통신은 도메인 이벤트를 통해 이루어짐
+
+### 2.2 해결 컨셉: 이벤트 기반 데이터 동기화
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                      Retrospective BC                            │
+│                                                                  │
+│  ┌──────────────────────┐                                       │
+│  │ CompleteRetrospective│                                       │
+│  │      Service         │                                       │
+│  └──────────┬───────────┘                                       │
+│             │                                                    │
+│             │ 회고 완료                                           │
+│             ▼                                                    │
+│  ┌──────────────────────┐                                       │
+│  │   Domain Event       │                                       │
+│  │ RetrospectiveCompleted│─────────────────────────────────────┐│
+│  └──────────────────────┘                                      ││
+└────────────────────────────────────────────────────────────────┘│
+                                                                   │
+┌──────────────────────────────────────────────────────────────────┼┐
+│                         Task BC                                  ││
+│                                                                  ││
+│  ┌──────────────────────┐      ┌───────────────────────────┐   ││
+│  │ RetrospectiveCompleted│◄─────│     Domain Event Bus      │◄──┘│
+│  │      Handler          │      └───────────────────────────┘    │
+│  └──────────┬───────────┘                                        │
+│             │                                                     │
+│             │ 1. 완료된 회고 기간 저장                              │
+│             │ 2. Task에 retrospectiveId 연결                      │
+│             ▼                                                     │
+│  ┌──────────────────────┐      ┌───────────────────────────┐    │
+│  │ CompletedRetrospective│      │      CreateTaskService    │    │
+│  │   PeriodRepository    │◄─────│                           │    │
+│  └──────────────────────┘      └───────────────────────────┘    │
+│             │                              │                      │
+│             │                              │ 검증: 완료된 회고      │
+│             │                              │ 기간과 겹치는지 확인   │
+│             ▼                              ▼                      │
+│  ┌──────────────────────────────────────────────────────────┐   │
+│  │              CompletedRetrospectivePeriod                 │   │
+│  │  - retrospectiveId                                        │   │
+│  │  - memberId                                               │   │
+│  │  - startDate                                              │   │
+│  │  - endDate                                                │   │
+│  │  - completedAt                                            │   │
+│  └──────────────────────────────────────────────────────────┘   │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+**핵심 아이디어:**
+
+회고가 완료되면 도메인 이벤트를 통해 Task BC에 해당 정보를 전달하고, Task BC는 자체적으로 `CompletedRetrospectivePeriod`를 저장하여 할일 생성/수정 시 검증에 사용합니다.
+
+이 방식의 장점:
+- BC 간 직접 의존성 없음
+- Task BC가 검증에 필요한 데이터를 자체적으로 보유
+- 이벤트 기반의 느슨한 결합(Loose Coupling)
+
+## 3. 구현 상세
+
+### 3.1 도메인 모델 추가
+
+**CompletedRetrospectivePeriod** - 완료된 회고 기간 정보
+
+```kotlin
+data class CompletedRetrospectivePeriod(
+    val retrospectiveId: RetrospectiveId,
+    val memberId: MemberId,
+    val startDate: LocalDate,
+    val endDate: LocalDate,
+    val completedAt: LocalDateTime,
+) {
+    // 특정 기간과 겹치는지 확인
+    fun overlaps(periodStart: LocalDate, periodEnd: LocalDate): Boolean =
+        !periodEnd.isBefore(startDate) && !periodStart.isAfter(endDate)
+
+    // 특정 날짜가 기간 내에 있는지 확인
+    fun contains(date: LocalDate): Boolean =
+        !date.isBefore(startDate) && !date.isAfter(endDate)
+}
+```
+
+### 3.2 이벤트 핸들러 수정
+
+**RetrospectiveCompletedHandler** - 회고 완료 이벤트 처리
+
+```kotlin
+@Component
+class RetrospectiveCompletedHandler(
+    private val taskRepository: TaskRepository,
+    private val completedRetrospectivePeriodRepository: CompletedRetrospectivePeriodRepository,
+) : DomainEventHandler<RetrospectiveEventPayload.Completed> {
+
+    override fun handle(event: DomainEvent<RetrospectiveEventPayload.Completed>) {
+        val payload = event.payload
+
+        // 1. 완료된 회고 기간 정보 저장
+        saveCompletedRetrospectivePeriod(payload)
+
+        // 2. 해당 기간의 Task들에 retrospectiveId 연결
+        linkTasksToRetrospective(payload)
+    }
+}
+```
+
+### 3.3 서비스 레이어 검증 추가
+
+**CreateTaskService** - 할일 생성 시 검증
+
+```kotlin
+@Service
+class CreateTaskService(
+    private val taskRepository: TaskRepository,
+    private val completedRetrospectivePeriodRepository: CompletedRetrospectivePeriodRepository,
+) : CreateTaskUseCase {
+
+    override fun execute(command: TaskApplicationCommand.CreateTask): TaskDto {
+        // 회고 완료된 기간과 겹치는지 검증
+        validateNotInCompletedRetrospectivePeriod(command)
+
+        // ... 기존 로직
+    }
+
+    private fun validateNotInCompletedRetrospectivePeriod(command: ...) {
+        val query = CompletedRetrospectivePeriodQuery.Offset.byMemberIdAndOverlappingPeriod(
+            memberId = command.memberId,
+            periodStart = command.startDate,
+            periodEnd = command.dueDate,
+        )
+
+        val overlappingPeriods = completedRetrospectivePeriodRepository.findAll(query).items
+
+        if (overlappingPeriods.isNotEmpty()) {
+            val period = overlappingPeriods.first()
+            throw IllegalArgumentException(
+                "회고가 완료된 기간(${period.startDate} ~ ${period.endDate})에는 할일을 추가할 수 없습니다."
+            )
+        }
+    }
+}
+```
+
+### 3.4 Repository 수정
+
+**ExposedTaskRepository** - retrospectiveDate 조회 구현
+
+```kotlin
+private fun findRetrospectiveEndDate(retrospectiveId: RetrospectiveId): LocalDate? =
+    CompletedRetrospectivePeriodTable
+        .selectAll()
+        .where { CompletedRetrospectivePeriodTable.retrospectiveId eq retrospectiveId.value }
+        .singleOrNull()
+        ?.get(CompletedRetrospectivePeriodTable.endDate)
+```
+
+이제 Task 수정 시 실제 회고 종료일을 조회하여 도메인 모델의 `validateModification()` 검증이 정상 동작합니다.
+
+## 4. 파일 변경 목록
+
+### 4.1 신규 파일
+
+| 파일 경로 | 설명 |
+|----------|------|
+| `task/domain/model/CompletedRetrospectivePeriod.kt` | 완료된 회고 기간 도메인 모델 |
+| `task/domain/model/command/CompletedRetrospectivePeriodCommand.kt` | Command 클래스 (Save, Delete) |
+| `task/domain/model/query/CompletedRetrospectivePeriodQuery.kt` | Query 클래스 (기간 겹침 조회 등) |
+| `task/domain/repository/CompletedRetrospectivePeriodRepository.kt` | Repository 인터페이스 |
+| `task/infrastructure/persistence/CompletedRetrospectivePeriodTable.kt` | Exposed 테이블 정의 |
+| `task/infrastructure/persistence/ExposedCompletedRetrospectivePeriodRepository.kt` | Repository 구현체 |
+
+### 4.2 수정 파일
+
+| 파일 경로 | 변경 내용 |
+|----------|----------|
+| `task/infrastructure/event/RetrospectiveCompletedHandler.kt` | 완료된 회고 기간 저장 로직 추가 |
+| `task/application/service/CreateTaskService.kt` | 회고 완료 기간 검증 로직 추가 |
+| `task/infrastructure/persistence/ExposedTaskRepository.kt` | retrospectiveDate 조회 TODO 구현 |
+
+### 4.3 테스트 파일
+
+| 파일 경로 | 변경 내용 |
+|----------|----------|
+| `task/application/service/CreateTaskServiceTest.kt` | 회고 완료 기간 검증 테스트 추가 |
+| `task/infrastructure/event/RetrospectiveCompletedHandlerTest.kt` | Repository mock 추가 |
+| `common/event/RetrospectiveCompletedIntegrationTest.kt` | Repository mock 추가 |
+
+## 5. 커밋 히스토리
+
+```
+8300e1a test: RetrospectiveCompletedHandler 테스트 수정
+abd2878 test: CreateTaskService 회고 완료 기간 검증 테스트 추가
+5b45ffd fix(task): ExposedTaskRepository TODO 수정 - retrospectiveDate 조회
+88f4d06 feat(task): CreateTaskService에 회고 완료 기간 검증 추가
+114ba6c feat(task): RetrospectiveCompletedHandler에 완료된 회고 기간 저장 추가
+5e93d24 feat(task): CompletedRetrospectivePeriod Infrastructure 추가
+310efe4 feat(task): CompletedRetrospectivePeriod 도메인 모델 추가
+```
+
+## 6. 검증 방법
+
+### 6.1 단위 테스트
+
+```bash
+./gradlew test --tests "xyz.robinjoon.growweek.task.application.service.CreateTaskServiceTest"
+```
+
+테스트 시나리오:
+- 회고가 완료된 기간에 할일 생성 시 `IllegalArgumentException` 발생
+- 회고가 완료되지 않은 기간에는 정상적으로 할일 생성
+
+### 6.2 통합 테스트
+
+```bash
+./gradlew test --tests "xyz.robinjoon.growweek.common.event.RetrospectiveCompletedIntegrationTest"
+```
+
+테스트 시나리오:
+- 회고 완료 시 완료된 기간 정보가 저장됨
+- 회고 완료 시 해당 기간의 Task에 retrospectiveId가 연결됨
+
+## 7. 향후 고려사항
+
+### 7.1 UpdateTaskService 검증 추가
+
+현재 `CreateTaskService`에만 검증 로직이 추가되었습니다. `UpdateTaskService`에도 동일한 검증 로직 추가를 고려해야 합니다. (단, 현재는 `Task.validateModification()` 도메인 메서드가 동작하므로 Repository 레벨에서 검증됨)
+
+### 7.2 데이터 정합성
+
+회고 완료 취소(DONE → IN_PROGRESS) 시 `CompletedRetrospectivePeriod` 삭제 로직이 필요할 수 있습니다. 현재 시스템에서 회고 완료 취소가 가능한지 확인 후 구현이 필요합니다.

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/task/application/service/CreateTaskService.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/task/application/service/CreateTaskService.kt
@@ -10,14 +10,20 @@ import xyz.robinjoon.growweek.task.domain.model.TaskDescription
 import xyz.robinjoon.growweek.task.domain.model.TaskPeriod
 import xyz.robinjoon.growweek.task.domain.model.TaskTitle
 import xyz.robinjoon.growweek.task.domain.model.command.TaskCommand
+import xyz.robinjoon.growweek.task.domain.model.query.CompletedRetrospectivePeriodQuery
+import xyz.robinjoon.growweek.task.domain.repository.CompletedRetrospectivePeriodRepository
 import xyz.robinjoon.growweek.task.domain.repository.TaskRepository
 
 @Service
 class CreateTaskService(
     private val taskRepository: TaskRepository,
+    private val completedRetrospectivePeriodRepository: CompletedRetrospectivePeriodRepository,
 ) : CreateTaskUseCase {
     @Transactional
     override fun execute(command: TaskApplicationCommand.CreateTask): TaskDto {
+        // 회고 완료된 기간과 겹치는지 검증
+        validateNotInCompletedRetrospectivePeriod(command)
+
         // Application Command를 Domain Command로 변환
         val domainCommand =
             TaskCommand.CreateTask(
@@ -34,5 +40,28 @@ class CreateTaskService(
         val createdTask = savedTasks.first()
 
         return TaskDto.from(createdTask)
+    }
+
+    /**
+     * 할일 기간이 완료된 회고 기간과 겹치는지 검증
+     *
+     * @throws IllegalArgumentException 회고가 완료된 기간에 할일을 생성하려고 할 때
+     */
+    private fun validateNotInCompletedRetrospectivePeriod(command: TaskApplicationCommand.CreateTask) {
+        val query =
+            CompletedRetrospectivePeriodQuery.Offset.byMemberIdAndOverlappingPeriod(
+                memberId = command.memberId,
+                periodStart = command.startDate,
+                periodEnd = command.dueDate,
+            )
+
+        val overlappingPeriods = completedRetrospectivePeriodRepository.findAll(query).items
+
+        if (overlappingPeriods.isNotEmpty()) {
+            val period = overlappingPeriods.first()
+            throw IllegalArgumentException(
+                "회고가 완료된 기간(${period.startDate} ~ ${period.endDate})에는 할일을 추가할 수 없습니다.",
+            )
+        }
     }
 }

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/task/domain/model/CompletedRetrospectivePeriod.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/task/domain/model/CompletedRetrospectivePeriod.kt
@@ -1,0 +1,36 @@
+package xyz.robinjoon.growweek.task.domain.model
+
+import xyz.robinjoon.growweek.common.domain.MemberId
+import xyz.robinjoon.growweek.common.domain.RetrospectiveId
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+/**
+ * 완료된 회고 기간 정보
+ *
+ * 회고가 완료되면 해당 기간 정보를 Task BC 내에 저장합니다.
+ * Task 생성/수정 시 이 정보를 조회하여 회고 완료된 기간에 대한 검증에 사용합니다.
+ *
+ * 이 도메인은 Retrospective BC를 직접 참조하지 않고,
+ * 도메인 이벤트를 통해 전달받은 정보를 저장합니다.
+ */
+data class CompletedRetrospectivePeriod(
+    val retrospectiveId: RetrospectiveId,
+    val memberId: MemberId,
+    val startDate: LocalDate,
+    val endDate: LocalDate,
+    val completedAt: LocalDateTime,
+) {
+    /**
+     * 주어진 기간이 이 회고 기간과 겹치는지 확인
+     */
+    fun overlaps(
+        periodStart: LocalDate,
+        periodEnd: LocalDate,
+    ): Boolean = !periodEnd.isBefore(startDate) && !periodStart.isAfter(endDate)
+
+    /**
+     * 주어진 날짜가 이 회고 기간에 포함되는지 확인
+     */
+    fun contains(date: LocalDate): Boolean = !date.isBefore(startDate) && !date.isAfter(endDate)
+}

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/task/domain/model/command/CompletedRetrospectivePeriodCommand.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/task/domain/model/command/CompletedRetrospectivePeriodCommand.kt
@@ -1,0 +1,29 @@
+package xyz.robinjoon.growweek.task.domain.model.command
+
+import xyz.robinjoon.growweek.common.domain.MemberId
+import xyz.robinjoon.growweek.common.domain.RetrospectiveId
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+/**
+ * 완료된 회고 기간 관련 Command
+ */
+sealed interface CompletedRetrospectivePeriodCommand {
+    /**
+     * 완료된 회고 기간 저장 커맨드
+     */
+    data class Save(
+        val retrospectiveId: RetrospectiveId,
+        val memberId: MemberId,
+        val startDate: LocalDate,
+        val endDate: LocalDate,
+        val completedAt: LocalDateTime = LocalDateTime.now(),
+    ) : CompletedRetrospectivePeriodCommand
+
+    /**
+     * 완료된 회고 기간 삭제 커맨드 (회고 삭제 시)
+     */
+    data class Delete(
+        val retrospectiveId: RetrospectiveId,
+    ) : CompletedRetrospectivePeriodCommand
+}

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/task/domain/model/query/CompletedRetrospectivePeriodQuery.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/task/domain/model/query/CompletedRetrospectivePeriodQuery.kt
@@ -1,0 +1,84 @@
+package xyz.robinjoon.growweek.task.domain.model.query
+
+import xyz.robinjoon.growweek.common.OffsetPageInfo
+import xyz.robinjoon.growweek.common.PageInfo
+import xyz.robinjoon.growweek.common.PageQuery
+import xyz.robinjoon.growweek.common.domain.MemberId
+import xyz.robinjoon.growweek.common.domain.RetrospectiveId
+import java.time.LocalDate
+
+/**
+ * 완료된 회고 기간 조회 Query
+ */
+sealed class CompletedRetrospectivePeriodQuery(
+    override val pageInfo: PageInfo,
+) : PageQuery {
+    /**
+     * Offset 기반 쿼리 팩토리
+     */
+    object Offset {
+        /**
+         * 특정 회원의 특정 기간과 겹치는 완료된 회고 조회
+         */
+        fun byMemberIdAndOverlappingPeriod(
+            memberId: MemberId,
+            periodStart: LocalDate,
+            periodEnd: LocalDate,
+            page: Int = 0,
+            size: Int = 100,
+        ): OffsetByMemberIdAndOverlappingPeriod =
+            OffsetByMemberIdAndOverlappingPeriod(
+                memberId = memberId,
+                periodStart = periodStart,
+                periodEnd = periodEnd,
+                pageInfo =
+                    OffsetPageInfo(
+                        page = page,
+                        size = size,
+                        orderBy = "completedAt",
+                    ),
+            )
+
+        /**
+         * 특정 회고 ID로 조회
+         */
+        fun byRetrospectiveId(
+            retrospectiveId: RetrospectiveId,
+            page: Int = 0,
+            size: Int = 1,
+        ): OffsetByRetrospectiveId =
+            OffsetByRetrospectiveId(
+                retrospectiveId = retrospectiveId,
+                pageInfo =
+                    OffsetPageInfo(
+                        page = page,
+                        size = size,
+                        orderBy = null,
+                    ),
+            )
+    }
+
+    /**
+     * 특정 회원의 특정 기간과 겹치는 완료된 회고 조회
+     */
+    data class OffsetByMemberIdAndOverlappingPeriod(
+        val memberId: MemberId,
+        val periodStart: LocalDate,
+        val periodEnd: LocalDate,
+        override val pageInfo: OffsetPageInfo,
+    ) : CompletedRetrospectivePeriodQuery(pageInfo) {
+        val page get() = pageInfo.page
+        val size get() = pageInfo.size
+    }
+
+    /**
+     * 특정 회고 ID로 조회
+     */
+    data class OffsetByRetrospectiveId(
+        val retrospectiveId: RetrospectiveId,
+        override val pageInfo: OffsetPageInfo,
+    ) : CompletedRetrospectivePeriodQuery(pageInfo) {
+        val page get() = pageInfo.page
+        val size get() = pageInfo.size
+    }
+}

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/task/domain/repository/CompletedRetrospectivePeriodRepository.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/task/domain/repository/CompletedRetrospectivePeriodRepository.kt
@@ -1,0 +1,30 @@
+package xyz.robinjoon.growweek.task.domain.repository
+
+import xyz.robinjoon.growweek.common.Page
+import xyz.robinjoon.growweek.task.domain.model.CompletedRetrospectivePeriod
+import xyz.robinjoon.growweek.task.domain.model.command.CompletedRetrospectivePeriodCommand
+import xyz.robinjoon.growweek.task.domain.model.query.CompletedRetrospectivePeriodQuery
+
+/**
+ * 완료된 회고 기간 Repository 인터페이스
+ *
+ * Domain Layer의 Repository 인터페이스로,
+ * Infrastructure Layer에서 구현됩니다.
+ */
+interface CompletedRetrospectivePeriodRepository {
+    /**
+     * 완료된 회고 기간 Command를 처리합니다.
+     *
+     * @param commands Command 목록
+     * @return 처리된 CompletedRetrospectivePeriod 목록
+     */
+    fun saveAll(commands: List<CompletedRetrospectivePeriodCommand>): List<CompletedRetrospectivePeriod>
+
+    /**
+     * Query 조건에 맞는 완료된 회고 기간을 조회합니다.
+     *
+     * @param query Query
+     * @return 페이징된 CompletedRetrospectivePeriod 목록
+     */
+    fun findAll(query: CompletedRetrospectivePeriodQuery): Page<CompletedRetrospectivePeriod>
+}

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/task/infrastructure/event/RetrospectiveCompletedHandler.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/task/infrastructure/event/RetrospectiveCompletedHandler.kt
@@ -5,20 +5,26 @@ import org.springframework.stereotype.Component
 import xyz.robinjoon.growweek.common.event.DomainEvent
 import xyz.robinjoon.growweek.common.event.DomainEventHandler
 import xyz.robinjoon.growweek.common.event.payload.RetrospectiveEventPayload
+import xyz.robinjoon.growweek.task.domain.model.command.CompletedRetrospectivePeriodCommand
 import xyz.robinjoon.growweek.task.domain.model.command.TaskCommand
 import xyz.robinjoon.growweek.task.domain.model.query.TaskQuery
+import xyz.robinjoon.growweek.task.domain.repository.CompletedRetrospectivePeriodRepository
 import xyz.robinjoon.growweek.task.domain.repository.TaskRepository
 import kotlin.reflect.KClass
 
 /**
  * 회고 완료 이벤트 핸들러
  *
- * 회고가 완료되면 해당 기간의 Task들에 retrospectiveId를 연결합니다.
+ * 회고가 완료되면:
+ * 1. 해당 기간의 Task들에 retrospectiveId를 연결합니다.
+ * 2. 완료된 회고 기간 정보를 저장합니다. (Task 생성/수정 시 검증에 사용)
+ *
  * DomainEventDispatcher에 의해 호출됩니다.
  */
 @Component
 class RetrospectiveCompletedHandler(
     private val taskRepository: TaskRepository,
+    private val completedRetrospectivePeriodRepository: CompletedRetrospectivePeriodRepository,
 ) : DomainEventHandler<RetrospectiveEventPayload.Completed> {
     private val log = LoggerFactory.getLogger(RetrospectiveCompletedHandler::class.java)
 
@@ -26,7 +32,26 @@ class RetrospectiveCompletedHandler(
         log.info("Handling Retrospective Completed Event: {}", event)
         val payload = event.payload
 
-        // 해당 기간의 Task 조회
+        // 1. 완료된 회고 기간 정보 저장
+        saveCompletedRetrospectivePeriod(payload)
+
+        // 2. 해당 기간의 Task 조회 및 회고 연결
+        linkTasksToRetrospective(payload)
+    }
+
+    private fun saveCompletedRetrospectivePeriod(payload: RetrospectiveEventPayload.Completed) {
+        val saveCommand =
+            CompletedRetrospectivePeriodCommand.Save(
+                retrospectiveId = payload.retrospectiveId,
+                memberId = payload.memberId,
+                startDate = payload.startDate,
+                endDate = payload.endDate,
+            )
+        completedRetrospectivePeriodRepository.saveAll(listOf(saveCommand))
+        log.info("Saved completed retrospective period: retrospectiveId={}", payload.retrospectiveId)
+    }
+
+    private fun linkTasksToRetrospective(payload: RetrospectiveEventPayload.Completed) {
         val query =
             TaskQuery.Offset.byMemberIdAndWeek(
                 memberId = payload.memberId,
@@ -36,7 +61,6 @@ class RetrospectiveCompletedHandler(
             )
         val tasks = taskRepository.findAll(query).items
 
-        // 각 Task에 회고 연결
         val linkCommands =
             tasks.map { task ->
                 TaskCommand.LinkRetrospective(
@@ -47,6 +71,7 @@ class RetrospectiveCompletedHandler(
 
         if (linkCommands.isNotEmpty()) {
             taskRepository.saveAll(linkCommands)
+            log.info("Linked {} tasks to retrospective: retrospectiveId={}", linkCommands.size, payload.retrospectiveId)
         }
     }
 

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/task/infrastructure/persistence/CompletedRetrospectivePeriodTable.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/task/infrastructure/persistence/CompletedRetrospectivePeriodTable.kt
@@ -1,0 +1,27 @@
+package xyz.robinjoon.growweek.task.infrastructure.persistence
+
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.javatime.date
+import org.jetbrains.exposed.v1.javatime.datetime
+
+/**
+ * 완료된 회고 기간 테이블
+ *
+ * 회고가 완료되면 해당 기간 정보를 저장합니다.
+ * Task 생성/수정 시 이 테이블을 조회하여 회고 완료된 기간에 대한 검증에 사용합니다.
+ */
+object CompletedRetrospectivePeriodTable : Table("completed_retrospective_periods") {
+    val retrospectiveId = long("retrospective_id")
+    val memberId = long("member_id")
+    val startDate = date("start_date")
+    val endDate = date("end_date")
+    val completedAt = datetime("completed_at")
+
+    override val primaryKey = PrimaryKey(retrospectiveId)
+
+    init {
+        // 회원별 기간 조회를 위한 인덱스
+        index(false, memberId, startDate, endDate)
+        index(false, memberId)
+    }
+}

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/task/infrastructure/persistence/ExposedCompletedRetrospectivePeriodRepository.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/task/infrastructure/persistence/ExposedCompletedRetrospectivePeriodRepository.kt
@@ -1,0 +1,121 @@
+package xyz.robinjoon.growweek.task.infrastructure.persistence
+
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.greaterEq
+import org.jetbrains.exposed.v1.core.lessEq
+import org.jetbrains.exposed.v1.jdbc.andWhere
+import org.jetbrains.exposed.v1.jdbc.deleteWhere
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+import xyz.robinjoon.growweek.common.OffsetPage
+import xyz.robinjoon.growweek.common.OffsetPageInfo
+import xyz.robinjoon.growweek.common.Page
+import xyz.robinjoon.growweek.common.domain.MemberId
+import xyz.robinjoon.growweek.common.domain.RetrospectiveId
+import xyz.robinjoon.growweek.task.domain.model.CompletedRetrospectivePeriod
+import xyz.robinjoon.growweek.task.domain.model.command.CompletedRetrospectivePeriodCommand
+import xyz.robinjoon.growweek.task.domain.model.query.CompletedRetrospectivePeriodQuery
+import xyz.robinjoon.growweek.task.domain.repository.CompletedRetrospectivePeriodRepository
+
+@Repository
+class ExposedCompletedRetrospectivePeriodRepository : CompletedRetrospectivePeriodRepository {
+    @Transactional
+    override fun saveAll(commands: List<CompletedRetrospectivePeriodCommand>): List<CompletedRetrospectivePeriod> {
+        val savedPeriods = mutableListOf<CompletedRetrospectivePeriod>()
+
+        commands.forEach { command ->
+            when (command) {
+                is CompletedRetrospectivePeriodCommand.Save -> {
+                    CompletedRetrospectivePeriodTable.insert {
+                        it[retrospectiveId] = command.retrospectiveId.value
+                        it[memberId] = command.memberId.value
+                        it[startDate] = command.startDate
+                        it[endDate] = command.endDate
+                        it[completedAt] = command.completedAt
+                    }
+
+                    savedPeriods.add(
+                        CompletedRetrospectivePeriod(
+                            retrospectiveId = command.retrospectiveId,
+                            memberId = command.memberId,
+                            startDate = command.startDate,
+                            endDate = command.endDate,
+                            completedAt = command.completedAt,
+                        ),
+                    )
+                }
+
+                is CompletedRetrospectivePeriodCommand.Delete -> {
+                    CompletedRetrospectivePeriodTable.deleteWhere {
+                        CompletedRetrospectivePeriodTable.retrospectiveId eq command.retrospectiveId.value
+                    }
+                }
+            }
+        }
+
+        return savedPeriods
+    }
+
+    @Transactional(readOnly = true)
+    override fun findAll(query: CompletedRetrospectivePeriodQuery): Page<CompletedRetrospectivePeriod> {
+        val pageInfo = query.pageInfo as OffsetPageInfo
+        var baseQuery = CompletedRetrospectivePeriodTable.selectAll()
+
+        when (query) {
+            is CompletedRetrospectivePeriodQuery.OffsetByMemberIdAndOverlappingPeriod -> {
+                baseQuery =
+                    baseQuery.andWhere {
+                        (CompletedRetrospectivePeriodTable.memberId eq query.memberId.value) and
+                            (CompletedRetrospectivePeriodTable.startDate lessEq query.periodEnd) and
+                            (CompletedRetrospectivePeriodTable.endDate greaterEq query.periodStart)
+                    }
+            }
+
+            is CompletedRetrospectivePeriodQuery.OffsetByRetrospectiveId -> {
+                baseQuery =
+                    baseQuery.andWhere {
+                        CompletedRetrospectivePeriodTable.retrospectiveId eq query.retrospectiveId.value
+                    }
+            }
+        }
+
+        // 정렬
+        baseQuery =
+            when (pageInfo.orderBy) {
+                "completedAt" -> baseQuery.orderBy(CompletedRetrospectivePeriodTable.completedAt to SortOrder.DESC)
+                else -> baseQuery.orderBy(CompletedRetrospectivePeriodTable.completedAt to SortOrder.DESC)
+            }
+
+        // 전체 개수
+        val totalCount = baseQuery.count().toInt()
+        val totalPage = if (totalCount == 0) 0 else (totalCount - 1) / pageInfo.size + 1
+
+        // 페이징
+        val items =
+            baseQuery
+                .limit(pageInfo.size)
+                .offset((pageInfo.page * pageInfo.size).toLong())
+                .map { it.toCompletedRetrospectivePeriod() }
+
+        return OffsetPage(
+            items = items,
+            page = pageInfo.page,
+            size = pageInfo.size,
+            totalPage = totalPage,
+        )
+    }
+
+    private fun ResultRow.toCompletedRetrospectivePeriod(): CompletedRetrospectivePeriod =
+        CompletedRetrospectivePeriod(
+            retrospectiveId = RetrospectiveId(this[CompletedRetrospectivePeriodTable.retrospectiveId]),
+            memberId = MemberId(this[CompletedRetrospectivePeriodTable.memberId]),
+            startDate = this[CompletedRetrospectivePeriodTable.startDate],
+            endDate = this[CompletedRetrospectivePeriodTable.endDate],
+            completedAt = this[CompletedRetrospectivePeriodTable.completedAt],
+        )
+}

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/task/infrastructure/persistence/ExposedTaskRepository.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/task/infrastructure/persistence/ExposedTaskRepository.kt
@@ -14,6 +14,7 @@ import xyz.robinjoon.growweek.task.domain.model.*
 import xyz.robinjoon.growweek.task.domain.model.command.TaskCommand
 import xyz.robinjoon.growweek.task.domain.model.query.TaskQuery
 import xyz.robinjoon.growweek.task.domain.repository.TaskRepository
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 @Repository
@@ -60,11 +61,10 @@ class ExposedTaskRepository : TaskRepository {
                             .singleOrNull()
                             ?: throw IllegalArgumentException("Task not found: ${command.taskId.value}")
 
-                    // 회고 날짜 확인 (회고가 있으면)
+                    // 회고 날짜 확인 (회고가 있으면 CompletedRetrospectivePeriod에서 종료일 조회)
                     val retrospectiveDate =
-                        existingTask.retrospectiveId?.let {
-                            // TODO: 실제로는 Retrospective를 조회해서 날짜를 가져와야 함
-                            null
+                        existingTask.retrospectiveId?.let { retroId ->
+                            findRetrospectiveEndDate(retroId)
                         }
 
                     // 업데이트 적용
@@ -104,7 +104,10 @@ class ExposedTaskRepository : TaskRepository {
                             .singleOrNull()
                             ?: throw IllegalArgumentException("Task not found: ${command.taskId.value}")
 
-                    val retrospectiveDate = existingTask.retrospectiveId?.let { null }
+                    val retrospectiveDate =
+                        existingTask.retrospectiveId?.let { retroId ->
+                            findRetrospectiveEndDate(retroId)
+                        }
                     val updatedTask = existingTask.updateStatus(command.status, retrospectiveDate)
 
                     // DB 업데이트
@@ -296,4 +299,18 @@ class ExposedTaskRepository : TaskRepository {
             updatedAt = this[TaskTable.updatedAt],
             retrospectiveId = this[TaskTable.retrospectiveId]?.let { RetrospectiveId(it) },
         )
+
+    /**
+     * 회고 ID로 완료된 회고 기간의 종료일을 조회
+     *
+     * @param retrospectiveId 회고 ID
+     * @return 회고 기간 종료일 (없으면 null)
+     */
+    private fun findRetrospectiveEndDate(retrospectiveId: RetrospectiveId): LocalDate? =
+        CompletedRetrospectivePeriodTable
+            .selectAll()
+            .where {
+                CompletedRetrospectivePeriodTable.retrospectiveId eq retrospectiveId.value
+            }.singleOrNull()
+            ?.get(CompletedRetrospectivePeriodTable.endDate)
 }

--- a/server/src/test/kotlin/xyz/robinjoon/growweek/common/event/RetrospectiveCompletedIntegrationTest.kt
+++ b/server/src/test/kotlin/xyz/robinjoon/growweek/common/event/RetrospectiveCompletedIntegrationTest.kt
@@ -19,8 +19,10 @@ import xyz.robinjoon.growweek.retrospective.domain.model.Answer
 import xyz.robinjoon.growweek.retrospective.domain.model.command.RetrospectiveCommand
 import xyz.robinjoon.growweek.retrospective.domain.repository.RetrospectiveRepository
 import xyz.robinjoon.growweek.task.domain.model.*
+import xyz.robinjoon.growweek.task.domain.model.command.CompletedRetrospectivePeriodCommand
 import xyz.robinjoon.growweek.task.domain.model.command.TaskCommand
 import xyz.robinjoon.growweek.task.domain.model.query.TaskQuery
+import xyz.robinjoon.growweek.task.domain.repository.CompletedRetrospectivePeriodRepository
 import xyz.robinjoon.growweek.task.domain.repository.TaskRepository
 import xyz.robinjoon.growweek.task.infrastructure.event.RetrospectiveCompletedHandler
 import java.time.LocalDate
@@ -42,9 +44,10 @@ class RetrospectiveCompletedIntegrationTest :
         Given("회고 완료 시 Task 연결 통합 테스트") {
             val retrospectiveRepository = mockk<RetrospectiveRepository>()
             val taskRepository = mockk<TaskRepository>()
+            val completedRetrospectivePeriodRepository = mockk<CompletedRetrospectivePeriodRepository>()
 
             // Handler 생성
-            val handler = RetrospectiveCompletedHandler(taskRepository)
+            val handler = RetrospectiveCompletedHandler(taskRepository, completedRetrospectivePeriodRepository)
 
             // 이벤트 캡처를 위한 slot
             val eventSlot = slot<Any>()
@@ -129,6 +132,19 @@ class RetrospectiveCompletedIntegrationTest :
                         completedRetrospective,
                     )
 
+                every {
+                    completedRetrospectivePeriodRepository.saveAll(any<List<CompletedRetrospectivePeriodCommand>>())
+                } returns
+                    listOf(
+                        CompletedRetrospectivePeriod(
+                            retrospectiveId = retrospectiveId,
+                            memberId = memberId,
+                            startDate = startDate,
+                            endDate = endDate,
+                            completedAt = now,
+                        ),
+                    )
+
                 every { taskRepository.findAll(any<TaskQuery>()) } returns
                     OffsetPage(
                         items = listOf(task1, task2),
@@ -194,6 +210,19 @@ class RetrospectiveCompletedIntegrationTest :
 
             And("해당 기간에 Task가 없는 경우") {
                 every { retrospectiveRepository.saveAll(any()) } returns listOf(completedRetrospective)
+
+                every {
+                    completedRetrospectivePeriodRepository.saveAll(any<List<CompletedRetrospectivePeriodCommand>>())
+                } returns
+                    listOf(
+                        CompletedRetrospectivePeriod(
+                            retrospectiveId = retrospectiveId,
+                            memberId = memberId,
+                            startDate = startDate,
+                            endDate = endDate,
+                            completedAt = now,
+                        ),
+                    )
 
                 every { taskRepository.findAll(any<TaskQuery>()) } returns
                     OffsetPage(

--- a/server/src/test/kotlin/xyz/robinjoon/growweek/task/application/service/CreateTaskServiceTest.kt
+++ b/server/src/test/kotlin/xyz/robinjoon/growweek/task/application/service/CreateTaskServiceTest.kt
@@ -1,18 +1,23 @@
 package xyz.robinjoon.growweek.task.application.service
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import xyz.robinjoon.growweek.common.OffsetPage
 import xyz.robinjoon.growweek.common.domain.MemberId
+import xyz.robinjoon.growweek.common.domain.RetrospectiveId
 import xyz.robinjoon.growweek.common.domain.SensitivityLevel
 import xyz.robinjoon.growweek.common.domain.TaskId
 import xyz.robinjoon.growweek.task.application.command.TaskApplicationCommand
 import xyz.robinjoon.growweek.task.domain.model.*
 import xyz.robinjoon.growweek.task.domain.model.command.TaskCommand
+import xyz.robinjoon.growweek.task.domain.repository.CompletedRetrospectivePeriodRepository
 import xyz.robinjoon.growweek.task.domain.repository.TaskRepository
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -23,7 +28,8 @@ class CreateTaskServiceTest :
         isolationMode = IsolationMode.InstancePerLeaf
 
         val taskRepository = mockk<TaskRepository>()
-        val service = CreateTaskService(taskRepository)
+        val completedRetrospectivePeriodRepository = mockk<CompletedRetrospectivePeriodRepository>()
+        val service = CreateTaskService(taskRepository, completedRetrospectivePeriodRepository)
 
         Given("할일 생성 요청이 왔을 때") {
             val memberId = MemberId(1L)
@@ -49,6 +55,7 @@ class CreateTaskServiceTest :
                 )
 
             val commandSlot = slot<List<TaskCommand>>()
+            every { completedRetrospectivePeriodRepository.findAll(any()) } returns emptyOffsetPage()
             every { taskRepository.saveAll(capture(commandSlot)) } returns listOf(savedTask)
 
             When("서비스를 실행하면") {
@@ -105,6 +112,7 @@ class CreateTaskServiceTest :
                     sensitivityLevel = command.sensitivityLevel,
                 )
 
+            every { completedRetrospectivePeriodRepository.findAll(any()) } returns emptyOffsetPage()
             every { taskRepository.saveAll(any()) } returns listOf(savedTask)
 
             When("서비스를 실행하면") {
@@ -116,6 +124,91 @@ class CreateTaskServiceTest :
 
                 Then("민감도가 TITLE_ONLY로 설정되어야 한다") {
                     result.sensitivityLevel shouldBe SensitivityLevel.TITLE_ONLY
+                }
+            }
+        }
+
+        Given("회고가 완료된 기간에 할일 생성 요청이 왔을 때") {
+            val memberId = MemberId(1L)
+            val retrospectiveStartDate = LocalDate.of(2025, 1, 6)
+            val retrospectiveEndDate = LocalDate.of(2025, 1, 12)
+
+            val command =
+                TaskApplicationCommand.CreateTask(
+                    memberId = memberId,
+                    title = "회고 완료 기간 할일",
+                    description = "테스트 설명",
+                    priority = 1,
+                    startDate = LocalDate.of(2025, 1, 8),
+                    dueDate = LocalDate.of(2025, 1, 10),
+                    sensitivityLevel = SensitivityLevel.NONE,
+                )
+
+            val completedPeriod =
+                createCompletedRetrospectivePeriod(
+                    retrospectiveId = RetrospectiveId(100L),
+                    memberId = memberId,
+                    startDate = retrospectiveStartDate,
+                    endDate = retrospectiveEndDate,
+                )
+
+            every {
+                completedRetrospectivePeriodRepository.findAll(any())
+            } returns OffsetPage(items = listOf(completedPeriod), page = 0, size = 100, totalPage = 1)
+
+            When("서비스를 실행하면") {
+                val exception =
+                    shouldThrow<IllegalArgumentException> {
+                        service.execute(command)
+                    }
+
+                Then("예외가 발생해야 한다") {
+                    exception.message shouldContain "회고가 완료된 기간"
+                    exception.message shouldContain retrospectiveStartDate.toString()
+                    exception.message shouldContain retrospectiveEndDate.toString()
+                }
+
+                Then("Repository에 저장 요청을 하지 않아야 한다") {
+                    verify(exactly = 0) { taskRepository.saveAll(any()) }
+                }
+            }
+        }
+
+        Given("회고가 완료되지 않은 기간에 할일 생성 요청이 왔을 때") {
+            val memberId = MemberId(1L)
+            val command =
+                TaskApplicationCommand.CreateTask(
+                    memberId = memberId,
+                    title = "회고 미완료 기간 할일",
+                    description = "테스트 설명",
+                    priority = 1,
+                    startDate = LocalDate.of(2025, 1, 13),
+                    dueDate = LocalDate.of(2025, 1, 19),
+                    sensitivityLevel = SensitivityLevel.NONE,
+                )
+
+            val savedTask =
+                createTask(
+                    title = command.title,
+                    description = command.description,
+                    priority = command.priority,
+                    startDate = command.startDate,
+                    dueDate = command.dueDate,
+                    sensitivityLevel = command.sensitivityLevel,
+                )
+
+            every { completedRetrospectivePeriodRepository.findAll(any()) } returns emptyOffsetPage()
+            every { taskRepository.saveAll(any()) } returns listOf(savedTask)
+
+            When("서비스를 실행하면") {
+                val result = service.execute(command)
+
+                Then("정상적으로 할일이 생성되어야 한다") {
+                    result.title.value shouldBe command.title
+                }
+
+                Then("Repository에 저장 요청을 해야 한다") {
+                    verify(exactly = 1) { taskRepository.saveAll(any()) }
                 }
             }
         }
@@ -144,3 +237,25 @@ private fun createTask(
         retrospectiveId = null,
     )
 }
+
+private fun createCompletedRetrospectivePeriod(
+    retrospectiveId: RetrospectiveId,
+    memberId: MemberId,
+    startDate: LocalDate,
+    endDate: LocalDate,
+): CompletedRetrospectivePeriod =
+    CompletedRetrospectivePeriod(
+        retrospectiveId = retrospectiveId,
+        memberId = memberId,
+        startDate = startDate,
+        endDate = endDate,
+        completedAt = LocalDateTime.now(),
+    )
+
+private fun emptyOffsetPage(): OffsetPage<CompletedRetrospectivePeriod> =
+    OffsetPage(
+        items = emptyList(),
+        page = 0,
+        size = 100,
+        totalPage = 0,
+    )

--- a/server/src/test/kotlin/xyz/robinjoon/growweek/task/infrastructure/event/RetrospectiveCompletedHandlerTest.kt
+++ b/server/src/test/kotlin/xyz/robinjoon/growweek/task/infrastructure/event/RetrospectiveCompletedHandlerTest.kt
@@ -16,8 +16,10 @@ import xyz.robinjoon.growweek.common.domain.TaskId
 import xyz.robinjoon.growweek.common.event.DefaultDomainEvent
 import xyz.robinjoon.growweek.common.event.payload.RetrospectiveEventPayload
 import xyz.robinjoon.growweek.task.domain.model.*
+import xyz.robinjoon.growweek.task.domain.model.command.CompletedRetrospectivePeriodCommand
 import xyz.robinjoon.growweek.task.domain.model.command.TaskCommand
 import xyz.robinjoon.growweek.task.domain.model.query.TaskQuery
+import xyz.robinjoon.growweek.task.domain.repository.CompletedRetrospectivePeriodRepository
 import xyz.robinjoon.growweek.task.domain.repository.TaskRepository
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -28,7 +30,8 @@ class RetrospectiveCompletedHandlerTest :
         isolationMode = IsolationMode.InstancePerLeaf
 
         val taskRepository = mockk<TaskRepository>()
-        val handler = RetrospectiveCompletedHandler(taskRepository)
+        val completedRetrospectivePeriodRepository = mockk<CompletedRetrospectivePeriodRepository>()
+        val handler = RetrospectiveCompletedHandler(taskRepository, completedRetrospectivePeriodRepository)
 
         Given("회고 완료 이벤트가 발행되었을 때") {
             val retrospectiveId = RetrospectiveId(1L)
@@ -50,6 +53,19 @@ class RetrospectiveCompletedHandlerTest :
             val now = LocalDateTime.now()
 
             And("해당 기간에 Task가 있는 경우") {
+                every {
+                    completedRetrospectivePeriodRepository.saveAll(any<List<CompletedRetrospectivePeriodCommand>>())
+                } returns
+                    listOf(
+                        CompletedRetrospectivePeriod(
+                            retrospectiveId = retrospectiveId,
+                            memberId = memberId,
+                            startDate = startDate,
+                            endDate = endDate,
+                            completedAt = now,
+                        ),
+                    )
+
                 val task1 =
                     Task(
                         id = TaskId(1L),
@@ -119,6 +135,19 @@ class RetrospectiveCompletedHandlerTest :
             }
 
             And("해당 기간에 Task가 없는 경우") {
+                every {
+                    completedRetrospectivePeriodRepository.saveAll(any<List<CompletedRetrospectivePeriodCommand>>())
+                } returns
+                    listOf(
+                        CompletedRetrospectivePeriod(
+                            retrospectiveId = retrospectiveId,
+                            memberId = memberId,
+                            startDate = startDate,
+                            endDate = endDate,
+                            completedAt = now,
+                        ),
+                    )
+
                 every { taskRepository.findAll(any<TaskQuery>()) } returns
                     OffsetPage(
                         items = emptyList(),


### PR DESCRIPTION
## Summary

- 회고가 완료된 기간에 할일을 추가할 수 없도록 검증 로직 추가
- 회고가 완료된 기간의 할일 수정 시 도메인 검증이 정상 동작하도록 수정
- Task BC 내에 CompletedRetrospectivePeriod 도메인 모델 추가하여 이벤트 기반 데이터 동기화 구현

## 변경 사항

### 신규 파일
- `CompletedRetrospectivePeriod` 도메인 모델, Command, Query, Repository
- `CompletedRetrospectivePeriodTable` 및 `ExposedCompletedRetrospectivePeriodRepository`

### 수정 파일
- `RetrospectiveCompletedHandler`: 완료된 회고 기간 저장 로직 추가
- `CreateTaskService`: 회고 완료 기간 검증 로직 추가
- `ExposedTaskRepository`: retrospectiveDate 조회 TODO 구현

### 문서
- `docs/completed-retrospective-period-validation.md`: 구현 상세 문서

## Test plan

- [x] CreateTaskService 회고 완료 기간 검증 테스트
- [x] RetrospectiveCompletedHandler 테스트
- [x] 통합 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)