### PR TITLE
refactor: fix architecture rule violations (1,2,3)

### DIFF
--- a/server/src/main/kotlin/xyz/robinjoon/growweek/common/infrastructure/security/JwtAuthenticationToken.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/common/infrastructure/security/JwtAuthenticationToken.kt
@@ -13,4 +13,6 @@ class JwtAuthenticationToken(
     override fun getCredentials(): Any? = null
 
     override fun getPrincipal(): MemberId = memberId
+
+    override fun getName(): String = memberId.value.toString()
 }

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/member/application/service/GetMemberService.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/member/application/service/GetMemberService.kt
@@ -13,9 +13,9 @@ class GetMemberService(
     private val memberRepository: MemberRepository,
 ) : GetMemberUseCase {
     @Transactional(readOnly = true)
-    override fun getMember(memberId: MemberId): MemberDto? {
+    override fun getMember(memberId: Long): MemberDto? {
         val member =
-            memberRepository.findAll(MemberQuery.byId(memberId)).items.firstOrNull()
+            memberRepository.findAll(MemberQuery.byId(MemberId(memberId))).items.firstOrNull()
                 ?: return null
 
         return MemberDto.from(member)

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/member/application/service/LoginService.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/member/application/service/LoginService.kt
@@ -3,19 +3,19 @@ package xyz.robinjoon.growweek.member.application.service
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import xyz.robinjoon.growweek.common.infrastructure.security.JwtTokenProvider
 import xyz.robinjoon.growweek.member.application.command.MemberApplicationCommand
 import xyz.robinjoon.growweek.member.application.dto.TokenDto
 import xyz.robinjoon.growweek.member.application.usecase.LoginUseCase
 import xyz.robinjoon.growweek.member.domain.model.Email
 import xyz.robinjoon.growweek.member.domain.model.query.MemberQuery
 import xyz.robinjoon.growweek.member.domain.repository.MemberRepository
+import xyz.robinjoon.growweek.member.domain.service.AccessTokenProvider
 
 @Service
 class LoginService(
     private val memberRepository: MemberRepository,
     private val passwordEncoder: PasswordEncoder,
-    private val jwtTokenProvider: JwtTokenProvider,
+    private val accessTokenProvider: AccessTokenProvider,
 ) : LoginUseCase {
     @Transactional(readOnly = true)
     override fun login(command: MemberApplicationCommand.Login): TokenDto {
@@ -33,11 +33,11 @@ class LoginService(
             throw IllegalArgumentException("이메일 또는 비밀번호가 올바르지 않습니다")
         }
 
-        val accessToken = jwtTokenProvider.createToken(member.id)
+        val accessToken = accessTokenProvider.createToken(member.id)
 
         return TokenDto(
             accessToken = accessToken,
-            expiresIn = jwtTokenProvider.getExpirationInSeconds(),
+            expiresIn = accessTokenProvider.getExpirationInSeconds(),
         )
     }
 }

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/member/application/usecase/GetMemberUseCase.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/member/application/usecase/GetMemberUseCase.kt
@@ -1,8 +1,7 @@
 package xyz.robinjoon.growweek.member.application.usecase
 
-import xyz.robinjoon.growweek.common.domain.MemberId
 import xyz.robinjoon.growweek.member.application.dto.MemberDto
 
 interface GetMemberUseCase {
-    fun getMember(memberId: MemberId): MemberDto?
+    fun getMember(memberId: Long): MemberDto?
 }

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/member/domain/service/AccessTokenProvider.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/member/domain/service/AccessTokenProvider.kt
@@ -1,0 +1,9 @@
+package xyz.robinjoon.growweek.member.domain.service
+
+import xyz.robinjoon.growweek.common.domain.MemberId
+
+interface AccessTokenProvider {
+    fun createToken(memberId: MemberId): String
+
+    fun getExpirationInSeconds(): Long
+}

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/member/infrastructure/external/JwtAccessTokenProvider.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/member/infrastructure/external/JwtAccessTokenProvider.kt
@@ -1,0 +1,15 @@
+package xyz.robinjoon.growweek.member.infrastructure.external
+
+import org.springframework.stereotype.Component
+import xyz.robinjoon.growweek.common.domain.MemberId
+import xyz.robinjoon.growweek.common.infrastructure.security.JwtTokenProvider
+import xyz.robinjoon.growweek.member.domain.service.AccessTokenProvider
+
+@Component
+class JwtAccessTokenProvider(
+    private val jwtTokenProvider: JwtTokenProvider,
+) : AccessTokenProvider {
+    override fun createToken(memberId: MemberId): String = jwtTokenProvider.createToken(memberId)
+
+    override fun getExpirationInSeconds(): Long = jwtTokenProvider.getExpirationInSeconds()
+}

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/member/presentation/rest/controller/MemberController.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/member/presentation/rest/controller/MemberController.kt
@@ -6,7 +6,6 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.*
-import xyz.robinjoon.growweek.common.infrastructure.security.JwtAuthenticationToken
 import xyz.robinjoon.growweek.member.application.command.MemberApplicationCommand
 import xyz.robinjoon.growweek.member.application.usecase.GetMemberUseCase
 import xyz.robinjoon.growweek.member.application.usecase.LoginUseCase
@@ -56,10 +55,14 @@ class MemberController(
     @GetMapping("/me")
     @Operation(summary = "현재 사용자 조회", description = "로그인된 사용자의 정보를 조회합니다")
     fun getCurrentMember(authentication: Authentication): ResponseEntity<MemberResponse> {
-        val memberId = (authentication as JwtAuthenticationToken).memberId
+        val memberId =
+            authentication.name.toLongOrNull()
+                ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
+
         val member =
             getMemberUseCase.getMember(memberId)
                 ?: return ResponseEntity.notFound().build()
+
         return ResponseEntity.ok(MemberResponse.from(member))
     }
 }

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/retrospective/application/command/RetrospectiveApplicationCommand.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/retrospective/application/command/RetrospectiveApplicationCommand.kt
@@ -39,4 +39,68 @@ sealed interface RetrospectiveApplicationCommand {
         val retrospectiveId: RetrospectiveId,
         val memberId: MemberId,
     ) : RetrospectiveApplicationCommand
+
+    companion object {
+        fun createRetrospective(
+            memberId: Long,
+            weekId: String,
+            questionCount: Int = 3,
+        ): CreateRetrospective =
+            CreateRetrospective(
+                memberId = MemberId(memberId),
+                weekId = WeekId(weekId),
+                questionCount = questionCount,
+            )
+
+        fun generateQuestions(
+            retrospectiveId: Long,
+            memberId: Long,
+        ): GenerateQuestions =
+            GenerateQuestions(
+                retrospectiveId = RetrospectiveId(retrospectiveId),
+                memberId = MemberId(memberId),
+            )
+
+        fun writeAnswer(
+            retrospectiveId: Long,
+            memberId: Long,
+            questionId: Long,
+            content: String?,
+        ): WriteAnswer =
+            WriteAnswer(
+                retrospectiveId = RetrospectiveId(retrospectiveId),
+                memberId = MemberId(memberId),
+                questionId = QuestionId(questionId),
+                content = content,
+            )
+
+        fun writeAdditionalNotes(
+            retrospectiveId: Long,
+            memberId: Long,
+            notes: String,
+        ): WriteAdditionalNotes =
+            WriteAdditionalNotes(
+                retrospectiveId = RetrospectiveId(retrospectiveId),
+                memberId = MemberId(memberId),
+                notes = notes,
+            )
+
+        fun completeRetrospective(
+            retrospectiveId: Long,
+            memberId: Long,
+        ): CompleteRetrospective =
+            CompleteRetrospective(
+                retrospectiveId = RetrospectiveId(retrospectiveId),
+                memberId = MemberId(memberId),
+            )
+
+        fun deleteRetrospective(
+            retrospectiveId: Long,
+            memberId: Long,
+        ): DeleteRetrospective =
+            DeleteRetrospective(
+                retrospectiveId = RetrospectiveId(retrospectiveId),
+                memberId = MemberId(memberId),
+            )
+    }
 }

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/retrospective/application/query/RetrospectiveApplicationQuery.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/retrospective/application/query/RetrospectiveApplicationQuery.kt
@@ -28,6 +28,13 @@ sealed class RetrospectiveApplicationQuery(
                     ),
             )
 
+        fun byMemberId(
+            memberId: Long,
+            cursor: String? = null,
+            size: Int = 20,
+            orderBy: String? = "createdAt",
+        ): CursorByMemberId = byMemberId(MemberId(memberId), cursor, size, orderBy)
+
         fun byMemberIdAndWeekId(
             memberId: MemberId,
             weekId: WeekId,
@@ -45,6 +52,14 @@ sealed class RetrospectiveApplicationQuery(
                         orderBy = orderBy,
                     ),
             )
+
+        fun byMemberIdAndWeekId(
+            memberId: Long,
+            weekId: String,
+            cursor: String? = null,
+            size: Int = 20,
+            orderBy: String? = "weekId",
+        ): CursorByMemberIdAndWeekId = byMemberIdAndWeekId(MemberId(memberId), WeekId(weekId), cursor, size, orderBy)
 
         fun byMemberIdAndMonth(
             memberId: MemberId,
@@ -65,6 +80,15 @@ sealed class RetrospectiveApplicationQuery(
                         orderBy = orderBy,
                     ),
             )
+
+        fun byMemberIdAndMonth(
+            memberId: Long,
+            year: Int,
+            month: Int,
+            cursor: String? = null,
+            size: Int = 20,
+            orderBy: String? = "weekId",
+        ): CursorByMemberIdAndMonth = byMemberIdAndMonth(MemberId(memberId), year, month, cursor, size, orderBy)
     }
 
     object Offset {
@@ -84,6 +108,13 @@ sealed class RetrospectiveApplicationQuery(
                     ),
             )
 
+        fun byMemberId(
+            memberId: Long,
+            page: Int = 0,
+            size: Int = 20,
+            orderBy: String? = "createdAt",
+        ): OffsetByMemberId = byMemberId(MemberId(memberId), page, size, orderBy)
+
         fun byMemberIdAndWeekId(
             memberId: MemberId,
             weekId: WeekId,
@@ -101,6 +132,14 @@ sealed class RetrospectiveApplicationQuery(
                         orderBy = orderBy,
                     ),
             )
+
+        fun byMemberIdAndWeekId(
+            memberId: Long,
+            weekId: String,
+            page: Int = 0,
+            size: Int = 20,
+            orderBy: String? = "weekId",
+        ): OffsetByMemberIdAndWeekId = byMemberIdAndWeekId(MemberId(memberId), WeekId(weekId), page, size, orderBy)
 
         fun byMemberIdAndMonth(
             memberId: MemberId,
@@ -121,6 +160,15 @@ sealed class RetrospectiveApplicationQuery(
                         orderBy = orderBy,
                     ),
             )
+
+        fun byMemberIdAndMonth(
+            memberId: Long,
+            year: Int,
+            month: Int,
+            page: Int = 0,
+            size: Int = 20,
+            orderBy: String? = "weekId",
+        ): OffsetByMemberIdAndMonth = byMemberIdAndMonth(MemberId(memberId), year, month, page, size, orderBy)
     }
 
     // 단건 조회
@@ -166,4 +214,15 @@ sealed class RetrospectiveApplicationQuery(
         val month: Int,
         override val pageInfo: OffsetPageInfo,
     ) : RetrospectiveApplicationQuery(pageInfo)
+
+    companion object {
+        fun byRetrospectiveId(
+            retrospectiveId: Long,
+            memberId: Long,
+        ): ByRetrospectiveId =
+            ByRetrospectiveId(
+                retrospectiveId = RetrospectiveId(retrospectiveId),
+                memberId = MemberId(memberId),
+            )
+    }
 }

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/retrospective/application/service/GenerateQuestionsService.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/retrospective/application/service/GenerateQuestionsService.kt
@@ -6,6 +6,7 @@ import xyz.robinjoon.growweek.common.domain.SensitivityLevel
 import xyz.robinjoon.growweek.retrospective.application.command.RetrospectiveApplicationCommand
 import xyz.robinjoon.growweek.retrospective.application.dto.RetrospectiveDto
 import xyz.robinjoon.growweek.retrospective.application.usecase.GenerateQuestionsUseCase
+import xyz.robinjoon.growweek.retrospective.domain.model.RetrospectiveTask
 import xyz.robinjoon.growweek.retrospective.domain.model.command.RetrospectiveCommand
 import xyz.robinjoon.growweek.retrospective.domain.model.query.RetrospectiveQuery
 import xyz.robinjoon.growweek.retrospective.domain.repository.RetrospectiveRepository
@@ -76,11 +77,21 @@ class GenerateQuestionsService(
         return RetrospectiveDto.from(savedRetrospectives.first())
     }
 
-    private fun filterTasksBySensitivity(tasks: List<Task>): List<Task> =
+    private fun filterTasksBySensitivity(tasks: List<Task>): List<RetrospectiveTask> =
         tasks.mapNotNull { task ->
             when (task.sensitivityLevel) {
-                SensitivityLevel.NONE -> task
-                SensitivityLevel.TITLE_ONLY -> task.copy(description = null)
+                SensitivityLevel.NONE ->
+                    RetrospectiveTask(
+                        title = task.title.value,
+                        description = task.description?.value,
+                        status = task.status.name,
+                    )
+                SensitivityLevel.TITLE_ONLY ->
+                    RetrospectiveTask(
+                        title = task.title.value,
+                        description = null,
+                        status = task.status.name,
+                    )
                 SensitivityLevel.NEVER -> null
             }
         }

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/retrospective/domain/model/RetrospectiveTask.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/retrospective/domain/model/RetrospectiveTask.kt
@@ -1,0 +1,7 @@
+package xyz.robinjoon.growweek.retrospective.domain.model
+
+data class RetrospectiveTask(
+    val title: String,
+    val description: String?,
+    val status: String,
+)

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/retrospective/domain/service/QuestionGenerationService.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/retrospective/domain/service/QuestionGenerationService.kt
@@ -1,7 +1,7 @@
 package xyz.robinjoon.growweek.retrospective.domain.service
 
 import xyz.robinjoon.growweek.retrospective.domain.model.QuestionCount
-import xyz.robinjoon.growweek.task.domain.model.Task
+import xyz.robinjoon.growweek.retrospective.domain.model.RetrospectiveTask
 
 /**
  * 회고 질문 생성 서비스 인터페이스
@@ -18,7 +18,7 @@ interface QuestionGenerationService {
      * @return 생성된 질문 내용 목록
      */
     suspend fun generateQuestions(
-        tasks: List<Task>,
+        tasks: List<RetrospectiveTask>,
         questionCount: QuestionCount,
     ): List<String>
 }

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/retrospective/infrastructure/external/MockQuestionGenerationService.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/retrospective/infrastructure/external/MockQuestionGenerationService.kt
@@ -2,8 +2,8 @@ package xyz.robinjoon.growweek.retrospective.infrastructure.external
 
 import org.springframework.stereotype.Service
 import xyz.robinjoon.growweek.retrospective.domain.model.QuestionCount
+import xyz.robinjoon.growweek.retrospective.domain.model.RetrospectiveTask
 import xyz.robinjoon.growweek.retrospective.domain.service.QuestionGenerationService
-import xyz.robinjoon.growweek.task.domain.model.Task
 
 /**
  * Mock 질문 생성 서비스
@@ -25,20 +25,20 @@ class MockQuestionGenerationService : QuestionGenerationService {
         )
 
     override suspend fun generateQuestions(
-        tasks: List<Task>,
+        tasks: List<RetrospectiveTask>,
         questionCount: QuestionCount,
     ): List<String> {
         val questions = mutableListOf<String>()
 
         if (tasks.isNotEmpty()) {
-            val completedTasks = tasks.filter { it.status.name == "DONE" }
-            val inProgressTasks = tasks.filter { it.status.name == "IN_PROGRESS" }
+            val completedTasks = tasks.filter { it.status == "DONE" }
+            val inProgressTasks = tasks.filter { it.status == "IN_PROGRESS" }
 
             if (completedTasks.isNotEmpty()) {
-                questions.add("완료한 '${completedTasks.first().title.value}' 작업에서 얻은 인사이트는 무엇인가요?")
+                questions.add("완료한 '${completedTasks.first().title}' 작업에서 얻은 인사이트는 무엇인가요?")
             }
             if (inProgressTasks.isNotEmpty()) {
-                questions.add("진행 중인 '${inProgressTasks.first().title.value}' 작업에서 어려운 점이 있나요?")
+                questions.add("진행 중인 '${inProgressTasks.first().title}' 작업에서 어려운 점이 있나요?")
             }
         }
 

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/retrospective/infrastructure/external/gemini/GeminiQuestionGenerationService.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/retrospective/infrastructure/external/gemini/GeminiQuestionGenerationService.kt
@@ -7,8 +7,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Primary
 import org.springframework.stereotype.Service
 import xyz.robinjoon.growweek.retrospective.domain.model.QuestionCount
+import xyz.robinjoon.growweek.retrospective.domain.model.RetrospectiveTask
 import xyz.robinjoon.growweek.retrospective.domain.service.QuestionGenerationService
-import xyz.robinjoon.growweek.task.domain.model.Task
 
 /**
  * Gemini API를 활용한 회고 질문 생성 서비스
@@ -26,7 +26,7 @@ class GeminiQuestionGenerationService(
     private val objectMapper = jacksonObjectMapper()
 
     override suspend fun generateQuestions(
-        tasks: List<Task>,
+        tasks: List<RetrospectiveTask>,
         questionCount: QuestionCount,
     ): List<String> {
         val prompt = buildPrompt(tasks, questionCount)
@@ -44,7 +44,7 @@ class GeminiQuestionGenerationService(
     }
 
     private fun buildPrompt(
-        tasks: List<Task>,
+        tasks: List<RetrospectiveTask>,
         questionCount: QuestionCount,
     ): String {
         val taskSummary =
@@ -74,30 +74,30 @@ class GeminiQuestionGenerationService(
             """.trimIndent()
     }
 
-    private fun buildTaskSummary(tasks: List<Task>): String {
-        val completedTasks = tasks.filter { it.status.name == "DONE" }
-        val inProgressTasks = tasks.filter { it.status.name == "IN_PROGRESS" }
-        val todoTasks = tasks.filter { it.status.name == "TODO" }
+    private fun buildTaskSummary(tasks: List<RetrospectiveTask>): String {
+        val completedTasks = tasks.filter { it.status == "DONE" }
+        val inProgressTasks = tasks.filter { it.status == "IN_PROGRESS" }
+        val todoTasks = tasks.filter { it.status == "TODO" }
 
         return buildString {
             if (completedTasks.isNotEmpty()) {
                 appendLine("완료된 할일:")
                 completedTasks.forEach { task ->
-                    appendLine("- ${task.title.value}")
+                    appendLine("- ${task.title}")
                 }
             }
 
             if (inProgressTasks.isNotEmpty()) {
                 appendLine("\n진행 중인 할일:")
                 inProgressTasks.forEach { task ->
-                    appendLine("- ${task.title.value}")
+                    appendLine("- ${task.title}")
                 }
             }
 
             if (todoTasks.isNotEmpty()) {
                 appendLine("\n시작하지 않은 할일:")
                 todoTasks.forEach { task ->
-                    appendLine("- ${task.title.value}")
+                    appendLine("- ${task.title}")
                 }
             }
 
@@ -142,20 +142,20 @@ class GeminiQuestionGenerationService(
     }
 
     private fun generateFallbackQuestions(
-        tasks: List<Task>,
+        tasks: List<RetrospectiveTask>,
         questionCount: QuestionCount,
     ): List<String> {
         val fallbackQuestions = mutableListOf<String>()
 
         if (tasks.isNotEmpty()) {
-            val completedTasks = tasks.filter { it.status.name == "DONE" }
-            val inProgressTasks = tasks.filter { it.status.name == "IN_PROGRESS" }
+            val completedTasks = tasks.filter { it.status == "DONE" }
+            val inProgressTasks = tasks.filter { it.status == "IN_PROGRESS" }
 
             if (completedTasks.isNotEmpty()) {
-                fallbackQuestions.add("완료한 '${completedTasks.first().title.value}' 작업에서 얻은 가장 큰 배움은 무엇인가요?")
+                fallbackQuestions.add("완료한 '${completedTasks.first().title}' 작업에서 얻은 가장 큰 배움은 무엇인가요?")
             }
             if (inProgressTasks.isNotEmpty()) {
-                fallbackQuestions.add("진행 중인 '${inProgressTasks.first().title.value}' 작업을 완료하기 위해 필요한 것은 무엇인가요?")
+                fallbackQuestions.add("진행 중인 '${inProgressTasks.first().title}' 작업을 완료하기 위해 필요한 것은 무엇인가요?")
             }
         }
 

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/retrospective/presentation/rest/controller/RetrospectiveController.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/retrospective/presentation/rest/controller/RetrospectiveController.kt
@@ -4,13 +4,9 @@ import kotlinx.coroutines.runBlocking
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
-import xyz.robinjoon.growweek.common.domain.MemberId
-import xyz.robinjoon.growweek.common.domain.RetrospectiveId
-import xyz.robinjoon.growweek.common.domain.WeekId
 import xyz.robinjoon.growweek.retrospective.application.command.RetrospectiveApplicationCommand
 import xyz.robinjoon.growweek.retrospective.application.query.RetrospectiveApplicationQuery
 import xyz.robinjoon.growweek.retrospective.application.usecase.*
-import xyz.robinjoon.growweek.retrospective.domain.model.QuestionId
 import xyz.robinjoon.growweek.retrospective.presentation.rest.request.CreateRetrospectiveRequest
 import xyz.robinjoon.growweek.retrospective.presentation.rest.request.WriteAdditionalNotesRequest
 import xyz.robinjoon.growweek.retrospective.presentation.rest.request.WriteAnswerRequest
@@ -44,9 +40,9 @@ class RetrospectiveController(
         @RequestHeader("X-User-Id") userId: Long,
     ): ResponseEntity<RetrospectiveResponse> {
         val command =
-            RetrospectiveApplicationCommand.CreateRetrospective(
-                memberId = MemberId(userId),
-                weekId = WeekId(request.weekId),
+            RetrospectiveApplicationCommand.createRetrospective(
+                memberId = userId,
+                weekId = request.weekId,
                 questionCount = request.questionCount,
             )
 
@@ -69,9 +65,9 @@ class RetrospectiveController(
         @RequestHeader("X-User-Id") userId: Long,
     ): ResponseEntity<RetrospectiveResponse> {
         val command =
-            RetrospectiveApplicationCommand.GenerateQuestions(
-                retrospectiveId = RetrospectiveId(retrospectiveId),
-                memberId = MemberId(userId),
+            RetrospectiveApplicationCommand.generateQuestions(
+                retrospectiveId = retrospectiveId,
+                memberId = userId,
             )
 
         val dto =
@@ -98,10 +94,10 @@ class RetrospectiveController(
         @RequestHeader("X-User-Id") userId: Long,
     ): ResponseEntity<RetrospectiveResponse> {
         val command =
-            RetrospectiveApplicationCommand.WriteAnswer(
-                retrospectiveId = RetrospectiveId(retrospectiveId),
-                memberId = MemberId(userId),
-                questionId = QuestionId(request.questionId),
+            RetrospectiveApplicationCommand.writeAnswer(
+                retrospectiveId = retrospectiveId,
+                memberId = userId,
+                questionId = request.questionId,
                 content = request.content,
             )
 
@@ -126,9 +122,9 @@ class RetrospectiveController(
         @RequestHeader("X-User-Id") userId: Long,
     ): ResponseEntity<RetrospectiveResponse> {
         val command =
-            RetrospectiveApplicationCommand.WriteAdditionalNotes(
-                retrospectiveId = RetrospectiveId(retrospectiveId),
-                memberId = MemberId(userId),
+            RetrospectiveApplicationCommand.writeAdditionalNotes(
+                retrospectiveId = retrospectiveId,
+                memberId = userId,
                 notes = request.notes,
             )
 
@@ -151,9 +147,9 @@ class RetrospectiveController(
         @RequestHeader("X-User-Id") userId: Long,
     ): ResponseEntity<RetrospectiveResponse> {
         val command =
-            RetrospectiveApplicationCommand.CompleteRetrospective(
-                retrospectiveId = RetrospectiveId(retrospectiveId),
-                memberId = MemberId(userId),
+            RetrospectiveApplicationCommand.completeRetrospective(
+                retrospectiveId = retrospectiveId,
+                memberId = userId,
             )
 
         val dto = completeRetrospectiveUseCase.execute(command)
@@ -175,9 +171,9 @@ class RetrospectiveController(
         @RequestHeader("X-User-Id") userId: Long,
     ): ResponseEntity<Void> {
         val command =
-            RetrospectiveApplicationCommand.DeleteRetrospective(
-                retrospectiveId = RetrospectiveId(retrospectiveId),
-                memberId = MemberId(userId),
+            RetrospectiveApplicationCommand.deleteRetrospective(
+                retrospectiveId = retrospectiveId,
+                memberId = userId,
             )
 
         deleteRetrospectiveUseCase.execute(command)
@@ -198,9 +194,9 @@ class RetrospectiveController(
         @RequestHeader("X-User-Id") userId: Long,
     ): ResponseEntity<RetrospectiveResponse> {
         val query =
-            RetrospectiveApplicationQuery.ByRetrospectiveId(
-                retrospectiveId = RetrospectiveId(retrospectiveId),
-                memberId = MemberId(userId),
+            RetrospectiveApplicationQuery.byRetrospectiveId(
+                retrospectiveId = retrospectiveId,
+                memberId = userId,
             )
 
         val dto = getRetrospectiveUseCase.getById(query)
@@ -229,7 +225,7 @@ class RetrospectiveController(
             if (cursor != null) {
                 val query =
                     RetrospectiveApplicationQuery.Cursor.byMemberId(
-                        memberId = MemberId(userId),
+                        memberId = userId,
                         cursor = cursor,
                         size = size ?: 20,
                     )
@@ -237,7 +233,7 @@ class RetrospectiveController(
             } else {
                 val query =
                     RetrospectiveApplicationQuery.Offset.byMemberId(
-                        memberId = MemberId(userId),
+                        memberId = userId,
                         page = page ?: 0,
                         size = size ?: 20,
                     )
@@ -265,7 +261,7 @@ class RetrospectiveController(
     ): ResponseEntity<MonthlyRetrospectiveResponse> {
         val query =
             RetrospectiveApplicationQuery.Offset.byMemberIdAndMonth(
-                memberId = MemberId(userId),
+                memberId = userId,
                 year = year,
                 month = month,
                 size = 31,

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/task/application/command/TaskApplicationCommand.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/task/application/command/TaskApplicationCommand.kt
@@ -49,4 +49,66 @@ sealed interface TaskApplicationCommand {
         val taskId: TaskId,
         val memberId: MemberId,
     ) : TaskApplicationCommand
+
+    companion object {
+        fun createTask(
+            memberId: Long,
+            title: String,
+            description: String?,
+            priority: Int,
+            dueDate: String,
+            sensitivityLevel: String? = null,
+        ): CreateTask =
+            CreateTask(
+                memberId = MemberId(memberId),
+                title = title,
+                description = description,
+                priority = priority,
+                dueDate = LocalDate.parse(dueDate),
+                sensitivityLevel = parseSensitivityLevel(sensitivityLevel),
+            )
+
+        fun updateTask(
+            taskId: Long,
+            memberId: Long,
+            title: String?,
+            description: String?,
+            status: String?,
+            priority: Int?,
+            dueDate: String?,
+            sensitivityLevel: String?,
+        ): UpdateTask =
+            UpdateTask(
+                taskId = TaskId(taskId),
+                memberId = MemberId(memberId),
+                title = title,
+                description = description,
+                status = status?.let(TaskStatus::valueOf),
+                priority = priority,
+                dueDate = dueDate?.let(LocalDate::parse),
+                sensitivityLevel = sensitivityLevel?.let(SensitivityLevel::valueOf),
+            )
+
+        fun updateTaskStatus(
+            taskId: Long,
+            memberId: Long,
+            status: String,
+        ): UpdateTaskStatus =
+            UpdateTaskStatus(
+                taskId = TaskId(taskId),
+                memberId = MemberId(memberId),
+                status = TaskStatus.valueOf(status),
+            )
+
+        fun deleteTask(
+            taskId: Long,
+            memberId: Long,
+        ): DeleteTask =
+            DeleteTask(
+                taskId = TaskId(taskId),
+                memberId = MemberId(memberId),
+            )
+
+        private fun parseSensitivityLevel(level: String?): SensitivityLevel = level?.let(SensitivityLevel::valueOf) ?: SensitivityLevel.NONE
+    }
 }

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/task/application/query/TaskApplicationQuery.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/task/application/query/TaskApplicationQuery.kt
@@ -31,6 +31,13 @@ sealed class TaskApplicationQuery(
                     ),
             )
 
+        fun byMemberId(
+            memberId: Long,
+            cursor: String? = null,
+            size: Int = 20,
+            orderBy: String? = "updatedAt",
+        ): CursorByMemberId = byMemberId(MemberId(memberId), cursor, size, orderBy)
+
         fun byMemberIdAndWeek(
             memberId: MemberId,
             weekId: WeekId,
@@ -49,6 +56,14 @@ sealed class TaskApplicationQuery(
                     ),
             )
 
+        fun byMemberIdAndWeek(
+            memberId: Long,
+            weekId: String,
+            cursor: String? = null,
+            size: Int = 20,
+            orderBy: String? = "priority",
+        ): CursorByMemberIdAndWeek = byMemberIdAndWeek(MemberId(memberId), WeekId(weekId), cursor, size, orderBy)
+
         fun byTaskId(
             taskId: TaskId,
             memberId: MemberId,
@@ -65,6 +80,13 @@ sealed class TaskApplicationQuery(
                         orderBy = null,
                     ),
             )
+
+        fun byTaskId(
+            taskId: Long,
+            memberId: Long,
+            cursor: String? = null,
+            size: Int = 1,
+        ): CursorByTaskId = byTaskId(TaskId(taskId), MemberId(memberId), cursor, size)
     }
 
     /**
@@ -87,6 +109,13 @@ sealed class TaskApplicationQuery(
                     ),
             )
 
+        fun byMemberId(
+            memberId: Long,
+            page: Int = 0,
+            size: Int = 20,
+            orderBy: String? = "updatedAt",
+        ): OffsetByMemberId = byMemberId(MemberId(memberId), page, size, orderBy)
+
         fun byMemberIdAndWeek(
             memberId: MemberId,
             weekId: WeekId,
@@ -105,6 +134,14 @@ sealed class TaskApplicationQuery(
                     ),
             )
 
+        fun byMemberIdAndWeek(
+            memberId: Long,
+            weekId: String,
+            page: Int = 0,
+            size: Int = 20,
+            orderBy: String? = "priority",
+        ): OffsetByMemberIdAndWeek = byMemberIdAndWeek(MemberId(memberId), WeekId(weekId), page, size, orderBy)
+
         fun byTaskId(
             taskId: TaskId,
             memberId: MemberId,
@@ -121,6 +158,13 @@ sealed class TaskApplicationQuery(
                         orderBy = null,
                     ),
             )
+
+        fun byTaskId(
+            taskId: Long,
+            memberId: Long,
+            page: Int = 0,
+            size: Int = 1,
+        ): OffsetByTaskId = byTaskId(TaskId(taskId), MemberId(memberId), page, size)
     }
 
     // Cursor 기반 쿼리 구현체들

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/task/presentation/rest/controller/TaskController.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/task/presentation/rest/controller/TaskController.kt
@@ -3,14 +3,9 @@ package xyz.robinjoon.growweek.task.presentation.rest.controller
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
-import xyz.robinjoon.growweek.common.domain.MemberId
-import xyz.robinjoon.growweek.common.domain.SensitivityLevel
-import xyz.robinjoon.growweek.common.domain.TaskId
-import xyz.robinjoon.growweek.common.domain.WeekId
 import xyz.robinjoon.growweek.task.application.command.TaskApplicationCommand
 import xyz.robinjoon.growweek.task.application.query.TaskApplicationQuery
 import xyz.robinjoon.growweek.task.application.usecase.*
-import xyz.robinjoon.growweek.task.domain.model.TaskStatus
 import xyz.robinjoon.growweek.task.presentation.rest.request.CreateTaskRequest
 import xyz.robinjoon.growweek.task.presentation.rest.request.UpdateTaskRequest
 import xyz.robinjoon.growweek.task.presentation.rest.request.UpdateTaskStatusRequest
@@ -18,7 +13,6 @@ import xyz.robinjoon.growweek.task.presentation.rest.response.PageResponse
 import xyz.robinjoon.growweek.task.presentation.rest.response.TaskResponse
 import xyz.robinjoon.growweek.task.presentation.rest.response.WeeklyTaskResponse
 import xyz.robinjoon.growweek.task.presentation.rest.response.toResponse
-import java.time.LocalDate
 
 /**
  * 할일 관리 API 컨트롤러
@@ -47,15 +41,13 @@ class TaskController(
         @RequestHeader("X-User-Id") userId: Long,
     ): ResponseEntity<TaskResponse> {
         val command =
-            TaskApplicationCommand.CreateTask(
-                memberId = MemberId(userId),
+            TaskApplicationCommand.createTask(
+                memberId = userId,
                 title = request.title,
                 description = request.description,
                 priority = request.priority,
-                dueDate = LocalDate.parse(request.dueDate),
-                sensitivityLevel =
-                    request.sensitivityLevel?.let { SensitivityLevel.valueOf(it) }
-                        ?: SensitivityLevel.NONE,
+                dueDate = request.dueDate,
+                sensitivityLevel = request.sensitivityLevel,
             )
 
         val taskDto = createTaskUseCase.execute(command)
@@ -79,15 +71,15 @@ class TaskController(
         @RequestHeader("X-User-Id") userId: Long,
     ): ResponseEntity<TaskResponse> {
         val command =
-            TaskApplicationCommand.UpdateTask(
-                taskId = TaskId(taskId),
-                memberId = MemberId(userId),
+            TaskApplicationCommand.updateTask(
+                taskId = taskId,
+                memberId = userId,
                 title = request.title,
                 description = request.description,
-                status = request.status?.let { TaskStatus.valueOf(it) },
+                status = request.status,
                 priority = request.priority,
-                dueDate = request.dueDate?.let { LocalDate.parse(it) },
-                sensitivityLevel = request.sensitivityLevel?.let { SensitivityLevel.valueOf(it) },
+                dueDate = request.dueDate,
+                sensitivityLevel = request.sensitivityLevel,
             )
 
         val taskDto = updateTaskUseCase.execute(command)
@@ -111,10 +103,10 @@ class TaskController(
         @RequestHeader("X-User-Id") userId: Long,
     ): ResponseEntity<TaskResponse> {
         val command =
-            TaskApplicationCommand.UpdateTaskStatus(
-                taskId = TaskId(taskId),
-                memberId = MemberId(userId),
-                status = TaskStatus.valueOf(request.status),
+            TaskApplicationCommand.updateTaskStatus(
+                taskId = taskId,
+                memberId = userId,
+                status = request.status,
             )
 
         val taskDto = updateTaskStatusUseCase.execute(command)
@@ -136,9 +128,9 @@ class TaskController(
         @RequestHeader("X-User-Id") userId: Long,
     ): ResponseEntity<Void> {
         val command =
-            TaskApplicationCommand.DeleteTask(
-                taskId = TaskId(taskId),
-                memberId = MemberId(userId),
+            TaskApplicationCommand.deleteTask(
+                taskId = taskId,
+                memberId = userId,
             )
 
         deleteTaskUseCase.execute(command)
@@ -160,8 +152,8 @@ class TaskController(
     ): ResponseEntity<TaskResponse> {
         val query =
             TaskApplicationQuery.Offset.byTaskId(
-                taskId = TaskId(taskId),
-                memberId = MemberId(userId),
+                taskId = taskId,
+                memberId = userId,
             )
 
         val taskDto =
@@ -191,15 +183,13 @@ class TaskController(
         @RequestParam(required = false) size: Int?,
         @RequestParam(required = false) cursor: String?,
     ): ResponseEntity<WeeklyTaskResponse> {
-        val week = WeekId(weekId)
-
         val weeklyDto =
             if (cursor != null) {
                 // Cursor 기반 페이징
                 val query =
                     TaskApplicationQuery.Cursor.byMemberIdAndWeek(
-                        memberId = MemberId(userId),
-                        weekId = week,
+                        memberId = userId,
+                        weekId = weekId,
                         cursor = cursor,
                         size = size ?: 20,
                     )
@@ -208,8 +198,8 @@ class TaskController(
                 // Offset 기반 페이징
                 val query =
                     TaskApplicationQuery.Offset.byMemberIdAndWeek(
-                        memberId = MemberId(userId),
-                        weekId = week,
+                        memberId = userId,
+                        weekId = weekId,
                         page = page ?: 0,
                         size = size ?: 20,
                     )
@@ -242,7 +232,7 @@ class TaskController(
                 // Cursor 기반 페이징
                 val query =
                     TaskApplicationQuery.Cursor.byMemberId(
-                        memberId = MemberId(userId),
+                        memberId = userId,
                         cursor = cursor,
                         size = size ?: 20,
                     )
@@ -251,7 +241,7 @@ class TaskController(
                 // Offset 기반 페이징
                 val query =
                     TaskApplicationQuery.Offset.byMemberId(
-                        memberId = MemberId(userId),
+                        memberId = userId,
                         page = page ?: 0,
                         size = size ?: 20,
                     )

--- a/server/src/test/kotlin/xyz/robinjoon/growweek/member/application/service/GetMemberServiceTest.kt
+++ b/server/src/test/kotlin/xyz/robinjoon/growweek/member/application/service/GetMemberServiceTest.kt
@@ -41,7 +41,7 @@ class GetMemberServiceTest :
                         totalPage = 1,
                     )
 
-                val result = getMemberService.getMember(memberId)
+                val result = getMemberService.getMember(memberId.value)
 
                 Then("MemberDto가 반환된다") {
                     result shouldNotBe null
@@ -53,7 +53,7 @@ class GetMemberServiceTest :
             }
 
             When("존재하지 않는 회원 ID로 조회하면") {
-                val memberId = MemberId(999L)
+                val memberId = 999L
 
                 every { memberRepository.findAll(any()) } returns
                     OffsetPage(

--- a/server/src/test/kotlin/xyz/robinjoon/growweek/member/application/service/LoginServiceTest.kt
+++ b/server/src/test/kotlin/xyz/robinjoon/growweek/member/application/service/LoginServiceTest.kt
@@ -9,10 +9,10 @@ import io.mockk.verify
 import org.springframework.security.crypto.password.PasswordEncoder
 import xyz.robinjoon.growweek.common.OffsetPage
 import xyz.robinjoon.growweek.common.domain.MemberId
-import xyz.robinjoon.growweek.common.infrastructure.security.JwtTokenProvider
 import xyz.robinjoon.growweek.member.application.command.MemberApplicationCommand
 import xyz.robinjoon.growweek.member.domain.model.*
 import xyz.robinjoon.growweek.member.domain.repository.MemberRepository
+import xyz.robinjoon.growweek.member.domain.service.AccessTokenProvider
 import java.time.LocalDateTime
 
 class LoginServiceTest :
@@ -20,8 +20,8 @@ class LoginServiceTest :
 
         val memberRepository = mockk<MemberRepository>()
         val passwordEncoder = mockk<PasswordEncoder>()
-        val jwtTokenProvider = mockk<JwtTokenProvider>()
-        val loginService = LoginService(memberRepository, passwordEncoder, jwtTokenProvider)
+        val accessTokenProvider = mockk<AccessTokenProvider>()
+        val loginService = LoginService(memberRepository, passwordEncoder, accessTokenProvider)
 
         Given("로그인 요청이 왔을 때") {
             val command =
@@ -51,8 +51,8 @@ class LoginServiceTest :
                         totalPage = 1,
                     )
                 every { passwordEncoder.matches(command.password, "encodedPassword") } returns true
-                every { jwtTokenProvider.createToken(MemberId(1L)) } returns "jwt.token.here"
-                every { jwtTokenProvider.getExpirationInSeconds() } returns 3600L
+                every { accessTokenProvider.createToken(MemberId(1L)) } returns "jwt.token.here"
+                every { accessTokenProvider.getExpirationInSeconds() } returns 3600L
 
                 val result = loginService.login(command)
 
@@ -62,8 +62,8 @@ class LoginServiceTest :
                     result.expiresIn shouldBe 3600L
                 }
 
-                Then("JWT 토큰이 생성된다") {
-                    verify(exactly = 1) { jwtTokenProvider.createToken(MemberId(1L)) }
+                Then("액세스 토큰이 생성된다") {
+                    verify(exactly = 1) { accessTokenProvider.createToken(MemberId(1L)) }
                 }
             }
 

--- a/server/src/test/kotlin/xyz/robinjoon/growweek/retrospective/application/service/GenerateQuestionsServiceTest.kt
+++ b/server/src/test/kotlin/xyz/robinjoon/growweek/retrospective/application/service/GenerateQuestionsServiceTest.kt
@@ -25,11 +25,11 @@ import java.time.LocalDateTime
  */
 class FakeQuestionGenerationService : QuestionGenerationService {
     var returnValue: List<String> = emptyList()
-    var capturedTasks: List<Task>? = null
+    var capturedTasks: List<RetrospectiveTask>? = null
     var capturedQuestionCount: QuestionCount? = null
 
     override suspend fun generateQuestions(
-        tasks: List<Task>,
+        tasks: List<RetrospectiveTask>,
         questionCount: QuestionCount,
     ): List<String> {
         capturedTasks = tasks
@@ -251,7 +251,7 @@ class GenerateQuestionsServiceTest :
                 Then("NEVER 민감도의 할일은 필터링되어야 한다") {
                     val filteredTasks = fakeQuestionGenerationService.capturedTasks!!
                     filteredTasks.size shouldBe 1
-                    filteredTasks.none { it.sensitivityLevel == SensitivityLevel.NEVER } shouldBe true
+                    filteredTasks.none { it.title == "비밀 할일" } shouldBe true
                 }
             }
         }

--- a/server/src/test/kotlin/xyz/robinjoon/growweek/retrospective/infrastructure/external/gemini/GeminiQuestionGenerationServiceTest.kt
+++ b/server/src/test/kotlin/xyz/robinjoon/growweek/retrospective/infrastructure/external/gemini/GeminiQuestionGenerationServiceTest.kt
@@ -7,14 +7,8 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.runBlocking
-import xyz.robinjoon.growweek.common.domain.MemberId
-import xyz.robinjoon.growweek.common.domain.SensitivityLevel
-import xyz.robinjoon.growweek.common.domain.TaskId
-import xyz.robinjoon.growweek.common.domain.WeekId
 import xyz.robinjoon.growweek.retrospective.domain.model.QuestionCount
-import xyz.robinjoon.growweek.task.domain.model.*
-import java.time.LocalDate
-import java.time.LocalDateTime
+import xyz.robinjoon.growweek.retrospective.domain.model.RetrospectiveTask
 
 class GeminiQuestionGenerationServiceTest :
     BehaviorSpec({
@@ -28,9 +22,9 @@ class GeminiQuestionGenerationServiceTest :
 
             val tasks =
                 listOf(
-                    createTask(TaskId(1L), "프로젝트 기획서 작성", TaskStatus.DONE),
-                    createTask(TaskId(2L), "코드 리뷰", TaskStatus.IN_PROGRESS),
-                    createTask(TaskId(3L), "회의 준비", TaskStatus.TODO),
+                    createTask("프로젝트 기획서 작성", "DONE"),
+                    createTask("코드 리뷰", "IN_PROGRESS"),
+                    createTask("회의 준비", "TODO"),
                 )
             val questionCount = QuestionCount(3)
 
@@ -72,7 +66,7 @@ class GeminiQuestionGenerationServiceTest :
 
             val tasks =
                 listOf(
-                    createTask(TaskId(1L), "완료된 작업", TaskStatus.DONE),
+                    createTask("완료된 작업", "DONE"),
                 )
             val questionCount = QuestionCount(3)
 
@@ -103,7 +97,7 @@ class GeminiQuestionGenerationServiceTest :
 
         Given("할일 목록이 비어있을 때") {
 
-            val emptyTasks = emptyList<Task>()
+            val emptyTasks = emptyList<RetrospectiveTask>()
             val questionCount = QuestionCount(3)
 
             When("질문 생성을 요청하면") {
@@ -123,10 +117,10 @@ class GeminiQuestionGenerationServiceTest :
 
             val tasks =
                 listOf(
-                    createTask(TaskId(1L), "완료된 작업 A", TaskStatus.DONE),
-                    createTask(TaskId(2L), "완료된 작업 B", TaskStatus.DONE),
-                    createTask(TaskId(3L), "진행 중인 작업", TaskStatus.IN_PROGRESS),
-                    createTask(TaskId(4L), "시작 전 작업", TaskStatus.TODO),
+                    createTask("완료된 작업 A", "DONE"),
+                    createTask("완료된 작업 B", "DONE"),
+                    createTask("진행 중인 작업", "IN_PROGRESS"),
+                    createTask("시작 전 작업", "TODO"),
                 )
 
             When("프롬프트를 생성하면") {
@@ -157,7 +151,7 @@ class GeminiQuestionGenerationServiceTest :
 
         Given("JSON이 아닌 텍스트 응답이 왔을 때") {
 
-            val tasks = listOf(createTask(TaskId(1L), "작업", TaskStatus.DONE))
+            val tasks = listOf(createTask("작업", "DONE"))
 
             When("번호가 붙은 질문 목록이 반환되면") {
                 val textResponse =
@@ -179,27 +173,14 @@ class GeminiQuestionGenerationServiceTest :
     })
 
 private fun createTask(
-    taskId: TaskId,
     title: String,
-    status: TaskStatus,
-): Task {
-    val now = LocalDateTime.now()
-    val weekId = WeekId.of(LocalDate.now().minusDays(7))
-    return Task(
-        id = taskId,
-        memberId = MemberId(1L),
-        title = TaskTitle(title),
-        description = TaskDescription("설명"),
+    status: String,
+): RetrospectiveTask =
+    RetrospectiveTask(
+        title = title,
+        description = "설명",
         status = status,
-        sensitivityLevel = SensitivityLevel.NONE,
-        priority = Priority(1),
-        weekId = weekId,
-        dueDate = weekId.endDate,
-        createdAt = now,
-        updatedAt = now,
-        retrospectiveId = null,
     )
-}
 
 private infix fun String?.shouldContainSubstring(substring: String) {
     this?.contains(substring) shouldBe true


### PR DESCRIPTION
## Summary
- Fix violation #1 by removing cross-bounded-context domain dependency from retrospective domain (`retrospective.domain` no longer imports `task.domain.Task`)
- Fix violation #2 by introducing a member token provider port (`AccessTokenProvider`) and infrastructure adapter (`JwtAccessTokenProvider`), and removing controller dependency on `JwtAuthenticationToken`
- Fix violation #3 by removing direct domain VO usage in presentation controllers via primitive-based command/query factory methods

## Key Changes
- Added `RetrospectiveTask` and updated question generation contract/implementations/tests
- Added `AccessTokenProvider` port and updated `LoginService`
- Updated `MemberController`, `TaskController`, `RetrospectiveController` to use primitive-based application factories
- Updated affected application/service tests

## Validation
- Ran `./gradlew ktlintFormat`
- Ran targeted tests:
  - `LoginServiceTest`
  - `GetMemberServiceTest`
  - `GenerateQuestionsServiceTest`
  - `GeminiQuestionGenerationServiceTest`

## Notes
- Full `./gradlew test` has unrelated existing failures in this repository (e.g., date/environment dependent tests), so validation focused on changed scope.
