### PR TITLE
refactor: Member LoginService의 Infrastructure 의존 제거

### DIFF
--- a/server/src/main/kotlin/xyz/robinjoon/growweek/common/infrastructure/security/JwtTokenProvider.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/common/infrastructure/security/JwtTokenProvider.kt
@@ -5,6 +5,7 @@ import io.jsonwebtoken.security.Keys
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import xyz.robinjoon.growweek.common.domain.MemberId
+import xyz.robinjoon.growweek.common.port.MemberTokenPort
 import java.util.*
 import javax.crypto.SecretKey
 
@@ -12,12 +13,12 @@ import javax.crypto.SecretKey
 class JwtTokenProvider(
     @Value("\${jwt.secret}") private val secret: String,
     @Value("\${jwt.expiration}") private val expirationMs: Long,
-) {
+) : MemberTokenPort {
     private val secretKey: SecretKey by lazy {
         Keys.hmacShaKeyFor(secret.toByteArray())
     }
 
-    fun createToken(memberId: MemberId): String {
+    override fun createToken(memberId: MemberId): String {
         val now = Date()
         val expiration = Date(now.time + expirationMs)
 
@@ -54,5 +55,5 @@ class JwtTokenProvider(
             false
         }
 
-    fun getExpirationInSeconds(): Long = expirationMs / 1000
+    override fun getExpirationInSeconds(): Long = expirationMs / 1000
 }

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/common/port/MemberTokenPort.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/common/port/MemberTokenPort.kt
@@ -1,0 +1,9 @@
+package xyz.robinjoon.growweek.common.port
+
+import xyz.robinjoon.growweek.common.domain.MemberId
+
+interface MemberTokenPort {
+    fun createToken(memberId: MemberId): String
+
+    fun getExpirationInSeconds(): Long
+}

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/member/application/service/LoginService.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/member/application/service/LoginService.kt
@@ -3,7 +3,7 @@ package xyz.robinjoon.growweek.member.application.service
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import xyz.robinjoon.growweek.common.infrastructure.security.JwtTokenProvider
+import xyz.robinjoon.growweek.common.port.MemberTokenPort
 import xyz.robinjoon.growweek.member.application.command.MemberApplicationCommand
 import xyz.robinjoon.growweek.member.application.dto.TokenDto
 import xyz.robinjoon.growweek.member.application.usecase.LoginUseCase
@@ -15,7 +15,7 @@ import xyz.robinjoon.growweek.member.domain.repository.MemberRepository
 class LoginService(
     private val memberRepository: MemberRepository,
     private val passwordEncoder: PasswordEncoder,
-    private val jwtTokenProvider: JwtTokenProvider,
+    private val memberTokenPort: MemberTokenPort,
 ) : LoginUseCase {
     @Transactional(readOnly = true)
     override fun login(command: MemberApplicationCommand.Login): TokenDto {
@@ -33,11 +33,11 @@ class LoginService(
             throw IllegalArgumentException("이메일 또는 비밀번호가 올바르지 않습니다")
         }
 
-        val accessToken = jwtTokenProvider.createToken(member.id)
+        val accessToken = memberTokenPort.createToken(member.id)
 
         return TokenDto(
             accessToken = accessToken,
-            expiresIn = jwtTokenProvider.getExpirationInSeconds(),
+            expiresIn = memberTokenPort.getExpirationInSeconds(),
         )
     }
 }

--- a/server/src/test/kotlin/xyz/robinjoon/growweek/member/application/service/LoginServiceTest.kt
+++ b/server/src/test/kotlin/xyz/robinjoon/growweek/member/application/service/LoginServiceTest.kt
@@ -9,7 +9,7 @@ import io.mockk.verify
 import org.springframework.security.crypto.password.PasswordEncoder
 import xyz.robinjoon.growweek.common.OffsetPage
 import xyz.robinjoon.growweek.common.domain.MemberId
-import xyz.robinjoon.growweek.common.infrastructure.security.JwtTokenProvider
+import xyz.robinjoon.growweek.common.port.MemberTokenPort
 import xyz.robinjoon.growweek.member.application.command.MemberApplicationCommand
 import xyz.robinjoon.growweek.member.domain.model.*
 import xyz.robinjoon.growweek.member.domain.repository.MemberRepository
@@ -20,8 +20,8 @@ class LoginServiceTest :
 
         val memberRepository = mockk<MemberRepository>()
         val passwordEncoder = mockk<PasswordEncoder>()
-        val jwtTokenProvider = mockk<JwtTokenProvider>()
-        val loginService = LoginService(memberRepository, passwordEncoder, jwtTokenProvider)
+        val memberTokenPort = mockk<MemberTokenPort>()
+        val loginService = LoginService(memberRepository, passwordEncoder, memberTokenPort)
 
         Given("로그인 요청이 왔을 때") {
             val command =
@@ -51,8 +51,8 @@ class LoginServiceTest :
                         totalPage = 1,
                     )
                 every { passwordEncoder.matches(command.password, "encodedPassword") } returns true
-                every { jwtTokenProvider.createToken(MemberId(1L)) } returns "jwt.token.here"
-                every { jwtTokenProvider.getExpirationInSeconds() } returns 3600L
+                every { memberTokenPort.createToken(MemberId(1L)) } returns "jwt.token.here"
+                every { memberTokenPort.getExpirationInSeconds() } returns 3600L
 
                 val result = loginService.login(command)
 
@@ -63,7 +63,7 @@ class LoginServiceTest :
                 }
 
                 Then("JWT 토큰이 생성된다") {
-                    verify(exactly = 1) { jwtTokenProvider.createToken(MemberId(1L)) }
+                    verify(exactly = 1) { memberTokenPort.createToken(MemberId(1L)) }
                 }
             }
 


### PR DESCRIPTION
## Summary
- Application 레이어의 `LoginService`가 `common.infrastructure.security.JwtTokenProvider`를 직접 참조하던 의존을 제거했습니다.
- 토큰 발급 추상화인 `MemberTokenPort`를 `common/port`에 추가하고, `JwtTokenProvider`가 해당 Port를 구현하도록 변경했습니다.
- `LoginServiceTest`를 Port 기반으로 수정해 로그인 토큰 발급 동작이 기존과 동일하게 유지됨을 검증했습니다.

## Details
- `member/application/**` 경로 내 `common.infrastructure.*` import를 0건으로 정리
- Spring DI는 `MemberTokenPort` 구현체(`JwtTokenProvider`)를 자동 주입하도록 유지

## Test
- `./gradlew test --tests "xyz.robinjoon.growweek.member.application.service.LoginServiceTest"`
- `./gradlew test --tests "xyz.robinjoon.growweek.member.application.service.*"`

Closes #14