### PR TITLE
refactor: Presentation 레이어의 Domain 의존 제거

### DIFF
--- a/server/src/main/kotlin/xyz/robinjoon/growweek/retrospective/application/command/RetrospectiveApplicationCommand.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/retrospective/application/command/RetrospectiveApplicationCommand.kt
@@ -10,33 +10,95 @@ sealed interface RetrospectiveApplicationCommand {
         val memberId: MemberId,
         val weekId: WeekId,
         val questionCount: Int = 3,
-    ) : RetrospectiveApplicationCommand
+    ) : RetrospectiveApplicationCommand {
+        constructor(
+            memberId: Long,
+            weekId: String,
+            questionCount: Int = 3,
+            @Suppress("UNUSED_PARAMETER") marker: Unit = Unit,
+        ) : this(
+            memberId = MemberId(memberId),
+            weekId = WeekId(weekId),
+            questionCount = questionCount,
+        )
+    }
 
     data class GenerateQuestions(
         val retrospectiveId: RetrospectiveId,
         val memberId: MemberId,
-    ) : RetrospectiveApplicationCommand
+    ) : RetrospectiveApplicationCommand {
+        constructor(
+            retrospectiveId: Long,
+            memberId: Long,
+            @Suppress("UNUSED_PARAMETER") marker: Unit = Unit,
+        ) : this(
+            retrospectiveId = RetrospectiveId(retrospectiveId),
+            memberId = MemberId(memberId),
+        )
+    }
 
     data class WriteAnswer(
         val retrospectiveId: RetrospectiveId,
         val memberId: MemberId,
         val questionId: QuestionId,
         val content: String?,
-    ) : RetrospectiveApplicationCommand
+    ) : RetrospectiveApplicationCommand {
+        constructor(
+            retrospectiveId: Long,
+            memberId: Long,
+            questionId: Long,
+            content: String?,
+            @Suppress("UNUSED_PARAMETER") marker: Unit = Unit,
+        ) : this(
+            retrospectiveId = RetrospectiveId(retrospectiveId),
+            memberId = MemberId(memberId),
+            questionId = QuestionId(questionId),
+            content = content,
+        )
+    }
 
     data class WriteAdditionalNotes(
         val retrospectiveId: RetrospectiveId,
         val memberId: MemberId,
         val notes: String,
-    ) : RetrospectiveApplicationCommand
+    ) : RetrospectiveApplicationCommand {
+        constructor(
+            retrospectiveId: Long,
+            memberId: Long,
+            notes: String,
+            @Suppress("UNUSED_PARAMETER") marker: Unit = Unit,
+        ) : this(
+            retrospectiveId = RetrospectiveId(retrospectiveId),
+            memberId = MemberId(memberId),
+            notes = notes,
+        )
+    }
 
     data class CompleteRetrospective(
         val retrospectiveId: RetrospectiveId,
         val memberId: MemberId,
-    ) : RetrospectiveApplicationCommand
+    ) : RetrospectiveApplicationCommand {
+        constructor(
+            retrospectiveId: Long,
+            memberId: Long,
+            @Suppress("UNUSED_PARAMETER") marker: Unit = Unit,
+        ) : this(
+            retrospectiveId = RetrospectiveId(retrospectiveId),
+            memberId = MemberId(memberId),
+        )
+    }
 
     data class DeleteRetrospective(
         val retrospectiveId: RetrospectiveId,
         val memberId: MemberId,
-    ) : RetrospectiveApplicationCommand
+    ) : RetrospectiveApplicationCommand {
+        constructor(
+            retrospectiveId: Long,
+            memberId: Long,
+            @Suppress("UNUSED_PARAMETER") marker: Unit = Unit,
+        ) : this(
+            retrospectiveId = RetrospectiveId(retrospectiveId),
+            memberId = MemberId(memberId),
+        )
+    }
 }

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/retrospective/application/query/RetrospectiveApplicationQuery.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/retrospective/application/query/RetrospectiveApplicationQuery.kt
@@ -28,6 +28,19 @@ sealed class RetrospectiveApplicationQuery(
                     ),
             )
 
+        fun byMemberId(
+            memberId: Long,
+            cursor: String? = null,
+            size: Int = 20,
+            orderBy: String? = "createdAt",
+        ): CursorByMemberId =
+            byMemberId(
+                memberId = MemberId(memberId),
+                cursor = cursor,
+                size = size,
+                orderBy = orderBy,
+            )
+
         fun byMemberIdAndWeekId(
             memberId: MemberId,
             weekId: WeekId,
@@ -44,6 +57,21 @@ sealed class RetrospectiveApplicationQuery(
                         size = size,
                         orderBy = orderBy,
                     ),
+            )
+
+        fun byMemberIdAndWeekId(
+            memberId: Long,
+            weekId: String,
+            cursor: String? = null,
+            size: Int = 20,
+            orderBy: String? = "weekId",
+        ): CursorByMemberIdAndWeekId =
+            byMemberIdAndWeekId(
+                memberId = MemberId(memberId),
+                weekId = WeekId(weekId),
+                cursor = cursor,
+                size = size,
+                orderBy = orderBy,
             )
 
         fun byMemberIdAndMonth(
@@ -65,6 +93,23 @@ sealed class RetrospectiveApplicationQuery(
                         orderBy = orderBy,
                     ),
             )
+
+        fun byMemberIdAndMonth(
+            memberId: Long,
+            year: Int,
+            month: Int,
+            cursor: String? = null,
+            size: Int = 20,
+            orderBy: String? = "weekId",
+        ): CursorByMemberIdAndMonth =
+            byMemberIdAndMonth(
+                memberId = MemberId(memberId),
+                year = year,
+                month = month,
+                cursor = cursor,
+                size = size,
+                orderBy = orderBy,
+            )
     }
 
     object Offset {
@@ -82,6 +127,19 @@ sealed class RetrospectiveApplicationQuery(
                         size = size,
                         orderBy = orderBy,
                     ),
+            )
+
+        fun byMemberId(
+            memberId: Long,
+            page: Int = 0,
+            size: Int = 20,
+            orderBy: String? = "createdAt",
+        ): OffsetByMemberId =
+            byMemberId(
+                memberId = MemberId(memberId),
+                page = page,
+                size = size,
+                orderBy = orderBy,
             )
 
         fun byMemberIdAndWeekId(
@@ -102,6 +160,21 @@ sealed class RetrospectiveApplicationQuery(
                     ),
             )
 
+        fun byMemberIdAndWeekId(
+            memberId: Long,
+            weekId: String,
+            page: Int = 0,
+            size: Int = 20,
+            orderBy: String? = "weekId",
+        ): OffsetByMemberIdAndWeekId =
+            byMemberIdAndWeekId(
+                memberId = MemberId(memberId),
+                weekId = WeekId(weekId),
+                page = page,
+                size = size,
+                orderBy = orderBy,
+            )
+
         fun byMemberIdAndMonth(
             memberId: MemberId,
             year: Int,
@@ -120,6 +193,34 @@ sealed class RetrospectiveApplicationQuery(
                         size = size,
                         orderBy = orderBy,
                     ),
+            )
+
+        fun byMemberIdAndMonth(
+            memberId: Long,
+            year: Int,
+            month: Int,
+            page: Int = 0,
+            size: Int = 20,
+            orderBy: String? = "weekId",
+        ): OffsetByMemberIdAndMonth =
+            byMemberIdAndMonth(
+                memberId = MemberId(memberId),
+                year = year,
+                month = month,
+                page = page,
+                size = size,
+                orderBy = orderBy,
+            )
+    }
+
+    companion object {
+        fun byRetrospectiveId(
+            retrospectiveId: Long,
+            memberId: Long,
+        ): ByRetrospectiveId =
+            ByRetrospectiveId(
+                retrospectiveId = RetrospectiveId(retrospectiveId),
+                memberId = MemberId(memberId),
             )
     }
 

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/retrospective/presentation/rest/controller/RetrospectiveController.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/retrospective/presentation/rest/controller/RetrospectiveController.kt
@@ -4,13 +4,9 @@ import kotlinx.coroutines.runBlocking
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
-import xyz.robinjoon.growweek.common.domain.MemberId
-import xyz.robinjoon.growweek.common.domain.RetrospectiveId
-import xyz.robinjoon.growweek.common.domain.WeekId
 import xyz.robinjoon.growweek.retrospective.application.command.RetrospectiveApplicationCommand
 import xyz.robinjoon.growweek.retrospective.application.query.RetrospectiveApplicationQuery
 import xyz.robinjoon.growweek.retrospective.application.usecase.*
-import xyz.robinjoon.growweek.retrospective.domain.model.QuestionId
 import xyz.robinjoon.growweek.retrospective.presentation.rest.request.CreateRetrospectiveRequest
 import xyz.robinjoon.growweek.retrospective.presentation.rest.request.WriteAdditionalNotesRequest
 import xyz.robinjoon.growweek.retrospective.presentation.rest.request.WriteAnswerRequest
@@ -45,8 +41,8 @@ class RetrospectiveController(
     ): ResponseEntity<RetrospectiveResponse> {
         val command =
             RetrospectiveApplicationCommand.CreateRetrospective(
-                memberId = MemberId(userId),
-                weekId = WeekId(request.weekId),
+                memberId = userId,
+                weekId = request.weekId,
                 questionCount = request.questionCount,
             )
 
@@ -70,8 +66,8 @@ class RetrospectiveController(
     ): ResponseEntity<RetrospectiveResponse> {
         val command =
             RetrospectiveApplicationCommand.GenerateQuestions(
-                retrospectiveId = RetrospectiveId(retrospectiveId),
-                memberId = MemberId(userId),
+                retrospectiveId = retrospectiveId,
+                memberId = userId,
             )
 
         val dto =
@@ -99,9 +95,9 @@ class RetrospectiveController(
     ): ResponseEntity<RetrospectiveResponse> {
         val command =
             RetrospectiveApplicationCommand.WriteAnswer(
-                retrospectiveId = RetrospectiveId(retrospectiveId),
-                memberId = MemberId(userId),
-                questionId = QuestionId(request.questionId),
+                retrospectiveId = retrospectiveId,
+                memberId = userId,
+                questionId = request.questionId,
                 content = request.content,
             )
 
@@ -127,8 +123,8 @@ class RetrospectiveController(
     ): ResponseEntity<RetrospectiveResponse> {
         val command =
             RetrospectiveApplicationCommand.WriteAdditionalNotes(
-                retrospectiveId = RetrospectiveId(retrospectiveId),
-                memberId = MemberId(userId),
+                retrospectiveId = retrospectiveId,
+                memberId = userId,
                 notes = request.notes,
             )
 
@@ -152,8 +148,8 @@ class RetrospectiveController(
     ): ResponseEntity<RetrospectiveResponse> {
         val command =
             RetrospectiveApplicationCommand.CompleteRetrospective(
-                retrospectiveId = RetrospectiveId(retrospectiveId),
-                memberId = MemberId(userId),
+                retrospectiveId = retrospectiveId,
+                memberId = userId,
             )
 
         val dto = completeRetrospectiveUseCase.execute(command)
@@ -176,8 +172,8 @@ class RetrospectiveController(
     ): ResponseEntity<Void> {
         val command =
             RetrospectiveApplicationCommand.DeleteRetrospective(
-                retrospectiveId = RetrospectiveId(retrospectiveId),
-                memberId = MemberId(userId),
+                retrospectiveId = retrospectiveId,
+                memberId = userId,
             )
 
         deleteRetrospectiveUseCase.execute(command)
@@ -198,9 +194,9 @@ class RetrospectiveController(
         @RequestHeader("X-User-Id") userId: Long,
     ): ResponseEntity<RetrospectiveResponse> {
         val query =
-            RetrospectiveApplicationQuery.ByRetrospectiveId(
-                retrospectiveId = RetrospectiveId(retrospectiveId),
-                memberId = MemberId(userId),
+            RetrospectiveApplicationQuery.byRetrospectiveId(
+                retrospectiveId = retrospectiveId,
+                memberId = userId,
             )
 
         val dto = getRetrospectiveUseCase.getById(query)
@@ -229,7 +225,7 @@ class RetrospectiveController(
             if (cursor != null) {
                 val query =
                     RetrospectiveApplicationQuery.Cursor.byMemberId(
-                        memberId = MemberId(userId),
+                        memberId = userId,
                         cursor = cursor,
                         size = size ?: 20,
                     )
@@ -237,7 +233,7 @@ class RetrospectiveController(
             } else {
                 val query =
                     RetrospectiveApplicationQuery.Offset.byMemberId(
-                        memberId = MemberId(userId),
+                        memberId = userId,
                         page = page ?: 0,
                         size = size ?: 20,
                     )
@@ -265,7 +261,7 @@ class RetrospectiveController(
     ): ResponseEntity<MonthlyRetrospectiveResponse> {
         val query =
             RetrospectiveApplicationQuery.Offset.byMemberIdAndMonth(
-                memberId = MemberId(userId),
+                memberId = userId,
                 year = year,
                 month = month,
                 size = 31,

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/task/application/command/TaskApplicationCommand.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/task/application/command/TaskApplicationCommand.kt
@@ -17,7 +17,24 @@ sealed interface TaskApplicationCommand {
         val priority: Int,
         val dueDate: LocalDate,
         val sensitivityLevel: SensitivityLevel = SensitivityLevel.NONE,
-    ) : TaskApplicationCommand
+    ) : TaskApplicationCommand {
+        constructor(
+            memberId: Long,
+            title: String,
+            description: String?,
+            priority: Int,
+            dueDate: String,
+            sensitivityLevel: String? = "NONE",
+            @Suppress("UNUSED_PARAMETER") marker: Unit = Unit,
+        ) : this(
+            memberId = MemberId(memberId),
+            title = title,
+            description = description,
+            priority = priority,
+            dueDate = LocalDate.parse(dueDate),
+            sensitivityLevel = sensitivityLevel?.let { SensitivityLevel.valueOf(it) } ?: SensitivityLevel.NONE,
+        )
+    }
 
     /**
      * 할일 수정 커맨드
@@ -31,7 +48,28 @@ sealed interface TaskApplicationCommand {
         val priority: Int?,
         val dueDate: LocalDate?,
         val sensitivityLevel: SensitivityLevel?,
-    ) : TaskApplicationCommand
+    ) : TaskApplicationCommand {
+        constructor(
+            taskId: Long,
+            memberId: Long,
+            title: String?,
+            description: String?,
+            status: String?,
+            priority: Int?,
+            dueDate: String?,
+            sensitivityLevel: String?,
+            @Suppress("UNUSED_PARAMETER") marker: Unit = Unit,
+        ) : this(
+            taskId = TaskId(taskId),
+            memberId = MemberId(memberId),
+            title = title,
+            description = description,
+            status = status?.let { TaskStatus.valueOf(it) },
+            priority = priority,
+            dueDate = dueDate?.let { LocalDate.parse(it) },
+            sensitivityLevel = sensitivityLevel?.let { SensitivityLevel.valueOf(it) },
+        )
+    }
 
     /**
      * 할일 상태 변경 커맨드
@@ -40,7 +78,18 @@ sealed interface TaskApplicationCommand {
         val taskId: TaskId,
         val memberId: MemberId,
         val status: TaskStatus,
-    ) : TaskApplicationCommand
+    ) : TaskApplicationCommand {
+        constructor(
+            taskId: Long,
+            memberId: Long,
+            status: String,
+            @Suppress("UNUSED_PARAMETER") marker: Unit = Unit,
+        ) : this(
+            taskId = TaskId(taskId),
+            memberId = MemberId(memberId),
+            status = TaskStatus.valueOf(status),
+        )
+    }
 
     /**
      * 할일 삭제 커맨드
@@ -48,5 +97,14 @@ sealed interface TaskApplicationCommand {
     data class DeleteTask(
         val taskId: TaskId,
         val memberId: MemberId,
-    ) : TaskApplicationCommand
+    ) : TaskApplicationCommand {
+        constructor(
+            taskId: Long,
+            memberId: Long,
+            @Suppress("UNUSED_PARAMETER") marker: Unit = Unit,
+        ) : this(
+            taskId = TaskId(taskId),
+            memberId = MemberId(memberId),
+        )
+    }
 }

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/task/application/query/TaskApplicationQuery.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/task/application/query/TaskApplicationQuery.kt
@@ -31,6 +31,19 @@ sealed class TaskApplicationQuery(
                     ),
             )
 
+        fun byMemberId(
+            memberId: Long,
+            cursor: String? = null,
+            size: Int = 20,
+            orderBy: String? = "updatedAt",
+        ): CursorByMemberId =
+            byMemberId(
+                memberId = MemberId(memberId),
+                cursor = cursor,
+                size = size,
+                orderBy = orderBy,
+            )
+
         fun byMemberIdAndWeek(
             memberId: MemberId,
             weekId: WeekId,
@@ -49,6 +62,21 @@ sealed class TaskApplicationQuery(
                     ),
             )
 
+        fun byMemberIdAndWeek(
+            memberId: Long,
+            weekId: String,
+            cursor: String? = null,
+            size: Int = 20,
+            orderBy: String? = "priority",
+        ): CursorByMemberIdAndWeek =
+            byMemberIdAndWeek(
+                memberId = MemberId(memberId),
+                weekId = WeekId(weekId),
+                cursor = cursor,
+                size = size,
+                orderBy = orderBy,
+            )
+
         fun byTaskId(
             taskId: TaskId,
             memberId: MemberId,
@@ -64,6 +92,19 @@ sealed class TaskApplicationQuery(
                         size = size,
                         orderBy = null,
                     ),
+            )
+
+        fun byTaskId(
+            taskId: Long,
+            memberId: Long,
+            cursor: String? = null,
+            size: Int = 1,
+        ): CursorByTaskId =
+            byTaskId(
+                taskId = TaskId(taskId),
+                memberId = MemberId(memberId),
+                cursor = cursor,
+                size = size,
             )
     }
 
@@ -87,6 +128,19 @@ sealed class TaskApplicationQuery(
                     ),
             )
 
+        fun byMemberId(
+            memberId: Long,
+            page: Int = 0,
+            size: Int = 20,
+            orderBy: String? = "updatedAt",
+        ): OffsetByMemberId =
+            byMemberId(
+                memberId = MemberId(memberId),
+                page = page,
+                size = size,
+                orderBy = orderBy,
+            )
+
         fun byMemberIdAndWeek(
             memberId: MemberId,
             weekId: WeekId,
@@ -105,6 +159,21 @@ sealed class TaskApplicationQuery(
                     ),
             )
 
+        fun byMemberIdAndWeek(
+            memberId: Long,
+            weekId: String,
+            page: Int = 0,
+            size: Int = 20,
+            orderBy: String? = "priority",
+        ): OffsetByMemberIdAndWeek =
+            byMemberIdAndWeek(
+                memberId = MemberId(memberId),
+                weekId = WeekId(weekId),
+                page = page,
+                size = size,
+                orderBy = orderBy,
+            )
+
         fun byTaskId(
             taskId: TaskId,
             memberId: MemberId,
@@ -120,6 +189,19 @@ sealed class TaskApplicationQuery(
                         size = size,
                         orderBy = null,
                     ),
+            )
+
+        fun byTaskId(
+            taskId: Long,
+            memberId: Long,
+            page: Int = 0,
+            size: Int = 1,
+        ): OffsetByTaskId =
+            byTaskId(
+                taskId = TaskId(taskId),
+                memberId = MemberId(memberId),
+                page = page,
+                size = size,
             )
     }
 

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/task/presentation/rest/controller/TaskController.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/task/presentation/rest/controller/TaskController.kt
@@ -3,14 +3,9 @@ package xyz.robinjoon.growweek.task.presentation.rest.controller
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
-import xyz.robinjoon.growweek.common.domain.MemberId
-import xyz.robinjoon.growweek.common.domain.SensitivityLevel
-import xyz.robinjoon.growweek.common.domain.TaskId
-import xyz.robinjoon.growweek.common.domain.WeekId
 import xyz.robinjoon.growweek.task.application.command.TaskApplicationCommand
 import xyz.robinjoon.growweek.task.application.query.TaskApplicationQuery
 import xyz.robinjoon.growweek.task.application.usecase.*
-import xyz.robinjoon.growweek.task.domain.model.TaskStatus
 import xyz.robinjoon.growweek.task.presentation.rest.request.CreateTaskRequest
 import xyz.robinjoon.growweek.task.presentation.rest.request.UpdateTaskRequest
 import xyz.robinjoon.growweek.task.presentation.rest.request.UpdateTaskStatusRequest
@@ -18,7 +13,6 @@ import xyz.robinjoon.growweek.task.presentation.rest.response.PageResponse
 import xyz.robinjoon.growweek.task.presentation.rest.response.TaskResponse
 import xyz.robinjoon.growweek.task.presentation.rest.response.WeeklyTaskResponse
 import xyz.robinjoon.growweek.task.presentation.rest.response.toResponse
-import java.time.LocalDate
 
 /**
  * 할일 관리 API 컨트롤러
@@ -48,14 +42,12 @@ class TaskController(
     ): ResponseEntity<TaskResponse> {
         val command =
             TaskApplicationCommand.CreateTask(
-                memberId = MemberId(userId),
+                memberId = userId,
                 title = request.title,
                 description = request.description,
                 priority = request.priority,
-                dueDate = LocalDate.parse(request.dueDate),
-                sensitivityLevel =
-                    request.sensitivityLevel?.let { SensitivityLevel.valueOf(it) }
-                        ?: SensitivityLevel.NONE,
+                dueDate = request.dueDate,
+                sensitivityLevel = request.sensitivityLevel,
             )
 
         val taskDto = createTaskUseCase.execute(command)
@@ -80,14 +72,14 @@ class TaskController(
     ): ResponseEntity<TaskResponse> {
         val command =
             TaskApplicationCommand.UpdateTask(
-                taskId = TaskId(taskId),
-                memberId = MemberId(userId),
+                taskId = taskId,
+                memberId = userId,
                 title = request.title,
                 description = request.description,
-                status = request.status?.let { TaskStatus.valueOf(it) },
+                status = request.status,
                 priority = request.priority,
-                dueDate = request.dueDate?.let { LocalDate.parse(it) },
-                sensitivityLevel = request.sensitivityLevel?.let { SensitivityLevel.valueOf(it) },
+                dueDate = request.dueDate,
+                sensitivityLevel = request.sensitivityLevel,
             )
 
         val taskDto = updateTaskUseCase.execute(command)
@@ -112,9 +104,9 @@ class TaskController(
     ): ResponseEntity<TaskResponse> {
         val command =
             TaskApplicationCommand.UpdateTaskStatus(
-                taskId = TaskId(taskId),
-                memberId = MemberId(userId),
-                status = TaskStatus.valueOf(request.status),
+                taskId = taskId,
+                memberId = userId,
+                status = request.status,
             )
 
         val taskDto = updateTaskStatusUseCase.execute(command)
@@ -137,8 +129,8 @@ class TaskController(
     ): ResponseEntity<Void> {
         val command =
             TaskApplicationCommand.DeleteTask(
-                taskId = TaskId(taskId),
-                memberId = MemberId(userId),
+                taskId = taskId,
+                memberId = userId,
             )
 
         deleteTaskUseCase.execute(command)
@@ -160,8 +152,8 @@ class TaskController(
     ): ResponseEntity<TaskResponse> {
         val query =
             TaskApplicationQuery.Offset.byTaskId(
-                taskId = TaskId(taskId),
-                memberId = MemberId(userId),
+                taskId = taskId,
+                memberId = userId,
             )
 
         val taskDto =
@@ -191,15 +183,13 @@ class TaskController(
         @RequestParam(required = false) size: Int?,
         @RequestParam(required = false) cursor: String?,
     ): ResponseEntity<WeeklyTaskResponse> {
-        val week = WeekId(weekId)
-
         val weeklyDto =
             if (cursor != null) {
                 // Cursor 기반 페이징
                 val query =
                     TaskApplicationQuery.Cursor.byMemberIdAndWeek(
-                        memberId = MemberId(userId),
-                        weekId = week,
+                        memberId = userId,
+                        weekId = weekId,
                         cursor = cursor,
                         size = size ?: 20,
                     )
@@ -208,8 +198,8 @@ class TaskController(
                 // Offset 기반 페이징
                 val query =
                     TaskApplicationQuery.Offset.byMemberIdAndWeek(
-                        memberId = MemberId(userId),
-                        weekId = week,
+                        memberId = userId,
+                        weekId = weekId,
                         page = page ?: 0,
                         size = size ?: 20,
                     )
@@ -242,7 +232,7 @@ class TaskController(
                 // Cursor 기반 페이징
                 val query =
                     TaskApplicationQuery.Cursor.byMemberId(
-                        memberId = MemberId(userId),
+                        memberId = userId,
                         cursor = cursor,
                         size = size ?: 20,
                     )
@@ -251,7 +241,7 @@ class TaskController(
                 // Offset 기반 페이징
                 val query =
                     TaskApplicationQuery.Offset.byMemberId(
-                        memberId = MemberId(userId),
+                        memberId = userId,
                         page = page ?: 0,
                         size = size ?: 20,
                     )


### PR DESCRIPTION
## Summary
- `TaskController`, `RetrospectiveController`에서 Domain VO/enum 직접 import 및 생성을 제거하고 primitive 값으로 `ApplicationCommand`/`ApplicationQuery`를 생성하도록 변경했습니다.
- `TaskApplicationCommand`, `RetrospectiveApplicationCommand`에 primitive 입력을 Domain 타입으로 변환하는 생성 경로를 추가해 Controller의 변환 책임을 Application 레이어로 이동했습니다.
- `TaskApplicationQuery`, `RetrospectiveApplicationQuery`에 primitive 기반 오버로드 팩토리를 추가해 Controller의 조회 파라미터 변환 로직을 정리했습니다.

## Test
- `./gradlew test --tests "xyz.robinjoon.growweek.task.application.service.*" --tests "xyz.robinjoon.growweek.retrospective.application.service.*"`
- `./gradlew ktlintCheck`

Closes #15