### PR TITLE
refactor: MemberController의 JwtAuthenticationToken 직접 의존 제거 (#16)

### DIFF
--- a/.claude/skills/infrastructure/SKILL.md
+++ b/.claude/skills/infrastructure/SKILL.md
@@ -14,6 +14,7 @@ description: Bounded Context에 새로운 infrastructure 를 추가하거나 수
 ```
 └── infrastructure/
     ├── persistence/
+    ├── security/
     └── external/
 ```
 
@@ -251,3 +252,11 @@ data class NotificationResponse(
         ├── kafka/
         └── aws/
 ```
+
+### 4. security 디렉토리
+
+security 디렉토리에는 Spring Security 관련 인프라 구현체가 위치합니다. 기능상 필요하지 않다면 이 디렉토리 안에는 파일이 존재하지 않을 수 있습니다. 예를 들어 JWT 인증 필터, 인증 토큰, ArgumentResolver 등이 이 디렉토리에 위치합니다.
+
+### 5. 기타 경로 추가
+
+위에 정의된 persistence, external, security 외에 새로운 하위 디렉토리가 필요한 경우 추가할 수 있습니다. 단, 새로운 경로를 추가할 경우 반드시 이 skills 문서에 해당 디렉토리의 역할과 규칙을 반영하고, 사용자에게 새로운 경로가 추가되었음을 분명히 응답해야 합니다.

--- a/.claude/skills/presentaion/SKILL.md
+++ b/.claude/skills/presentaion/SKILL.md
@@ -71,7 +71,22 @@ class TaskController(
 }
 ```
 
-### 3. 별도 디렉토리
+### 3. 인증된 사용자 정보 주입
+
+인증이 필요한 엔드포인트에서 현재 로그인된 사용자의 ID를 받을 때는 `@CurrentMemberId` 애너테이션을 사용합니다. 타입은 반드시 `Long`(Primitive Type)을 사용합니다.
+
+```kotlin
+import xyz.robinjoon.growweek.common.presentation.security.CurrentMemberId
+
+@GetMapping("/me")
+fun getCurrentMember(
+    @CurrentMemberId memberId: Long,
+): ResponseEntity<MemberResponse> {
+    // ...
+}
+```
+
+### 4. 별도 디렉토리
 
 필요에 따라 presentation 레이어 내에 추가적인 디렉토리를 생성할 수 있습니다. 예를 들어, GraphQL API를 위한 디렉토리나 WebSocket 관련 디렉토리를 추가할 수 있습니다.
 각 디렉토리의 하위에 rest 디렉토리와 유사하게 request, response, controller 등의 하위 디렉토리를 포함할 수 있습니다.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -155,6 +155,7 @@ xyz.robinjoon.growweek/
   - 기반 인터페이스/추상 클래스
   - 공통 설정 (Security, OpenAPI, Redis 등)
   - 공통 응답 포맷
+- **하위 구조**: 다른 Bounded Context의 레이어 구조(presentation, application, domain, infrastructure)에서 필요한 것만 만들어서 사용합니다.
 
 ## CQRS 패턴 적용
 

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/common/config/WebMvcConfig.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/common/config/WebMvcConfig.kt
@@ -1,0 +1,15 @@
+package xyz.robinjoon.growweek.common.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+import xyz.robinjoon.growweek.common.infrastructure.security.CurrentMemberIdArgumentResolver
+
+@Configuration
+class WebMvcConfig(
+    private val currentMemberIdArgumentResolver: CurrentMemberIdArgumentResolver,
+) : WebMvcConfigurer {
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
+        resolvers.add(currentMemberIdArgumentResolver)
+    }
+}

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/common/infrastructure/security/CurrentMemberIdArgumentResolver.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/common/infrastructure/security/CurrentMemberIdArgumentResolver.kt
@@ -1,0 +1,30 @@
+package xyz.robinjoon.growweek.common.infrastructure.security
+
+import org.springframework.core.MethodParameter
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+import xyz.robinjoon.growweek.common.presentation.security.CurrentMemberId
+
+@Component
+class CurrentMemberIdArgumentResolver : HandlerMethodArgumentResolver {
+    override fun supportsParameter(parameter: MethodParameter): Boolean =
+        parameter.hasParameterAnnotation(CurrentMemberId::class.java) &&
+            parameter.parameterType == Long::class.java
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?,
+    ): Long {
+        val authentication =
+            SecurityContextHolder.getContext().authentication
+                as? JwtAuthenticationToken
+                ?: throw IllegalStateException("인증 정보가 존재하지 않습니다.")
+        return authentication.memberId.value
+    }
+}

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/common/presentation/security/CurrentMemberId.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/common/presentation/security/CurrentMemberId.kt
@@ -1,0 +1,5 @@
+package xyz.robinjoon.growweek.common.presentation.security
+
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class CurrentMemberId

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/member/application/service/GetMemberService.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/member/application/service/GetMemberService.kt
@@ -13,9 +13,9 @@ class GetMemberService(
     private val memberRepository: MemberRepository,
 ) : GetMemberUseCase {
     @Transactional(readOnly = true)
-    override fun getMember(memberId: MemberId): MemberDto? {
+    override fun getMember(memberId: Long): MemberDto? {
         val member =
-            memberRepository.findAll(MemberQuery.byId(memberId)).items.firstOrNull()
+            memberRepository.findAll(MemberQuery.byId(MemberId(memberId))).items.firstOrNull()
                 ?: return null
 
         return MemberDto.from(member)

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/member/application/usecase/GetMemberUseCase.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/member/application/usecase/GetMemberUseCase.kt
@@ -1,8 +1,7 @@
 package xyz.robinjoon.growweek.member.application.usecase
 
-import xyz.robinjoon.growweek.common.domain.MemberId
 import xyz.robinjoon.growweek.member.application.dto.MemberDto
 
 interface GetMemberUseCase {
-    fun getMember(memberId: MemberId): MemberDto?
+    fun getMember(memberId: Long): MemberDto?
 }

--- a/server/src/main/kotlin/xyz/robinjoon/growweek/member/presentation/rest/controller/MemberController.kt
+++ b/server/src/main/kotlin/xyz/robinjoon/growweek/member/presentation/rest/controller/MemberController.kt
@@ -4,9 +4,8 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.*
-import xyz.robinjoon.growweek.common.infrastructure.security.JwtAuthenticationToken
+import xyz.robinjoon.growweek.common.presentation.security.CurrentMemberId
 import xyz.robinjoon.growweek.member.application.command.MemberApplicationCommand
 import xyz.robinjoon.growweek.member.application.usecase.GetMemberUseCase
 import xyz.robinjoon.growweek.member.application.usecase.LoginUseCase
@@ -55,8 +54,9 @@ class MemberController(
 
     @GetMapping("/me")
     @Operation(summary = "현재 사용자 조회", description = "로그인된 사용자의 정보를 조회합니다")
-    fun getCurrentMember(authentication: Authentication): ResponseEntity<MemberResponse> {
-        val memberId = (authentication as JwtAuthenticationToken).memberId
+    fun getCurrentMember(
+        @CurrentMemberId memberId: Long,
+    ): ResponseEntity<MemberResponse> {
         val member =
             getMemberUseCase.getMember(memberId)
                 ?: return ResponseEntity.notFound().build()

--- a/server/src/test/kotlin/xyz/robinjoon/growweek/member/application/service/GetMemberServiceTest.kt
+++ b/server/src/test/kotlin/xyz/robinjoon/growweek/member/application/service/GetMemberServiceTest.kt
@@ -41,7 +41,7 @@ class GetMemberServiceTest :
                         totalPage = 1,
                     )
 
-                val result = getMemberService.getMember(memberId)
+                val result = getMemberService.getMember(memberId.value)
 
                 Then("MemberDto가 반환된다") {
                     result shouldNotBe null
@@ -53,7 +53,7 @@ class GetMemberServiceTest :
             }
 
             When("존재하지 않는 회원 ID로 조회하면") {
-                val memberId = MemberId(999L)
+                val memberId = 999L
 
                 every { memberRepository.findAll(any()) } returns
                     OffsetPage(


### PR DESCRIPTION
## Summary
- `@CurrentMemberId` 애너테이션 + `CurrentMemberIdArgumentResolver` 도입으로 MemberController에서 `JwtAuthenticationToken`(infrastructure) 직접 캐스팅 제거
- `GetMemberUseCase` 시그니처를 `Long`으로 변경하여 presentation → domain 의존도 함께 제거
- ARCHITECTURE.md에 common 하위 구조 규칙 추가, infrastructure/presentation skills에 security 디렉토리 및 인증 패턴 규약 보강

## Test plan
- [x] `member/presentation/**`에서 `*.infrastructure.*` import 0건 확인
- [x] `member/presentation/**`에서 `*.domain.*` import 0건 확인
- [x] 전체 빌드 및 테스트 통과 확인
- [x] `/api/v1/members/me` 엔드포인트 동작 수동 확인

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)