### PR TITLE
docs: infrastructure/event 디렉토리 규칙 정합성 통일 (#17)

### DIFF
--- a/.claude/skills/event/SKILL.md
+++ b/.claude/skills/event/SKILL.md
@@ -38,15 +38,15 @@ description: Bounded Context에 새로운 도메인 이벤트 핸들러를 추�
 @Component
 class SomeEventHandler(
     private val someRepository: SomeRepository,
-) : DomainEventHandler<SomeEventPayload> {
+) : DomainEventHandler<SomeEventPayload.Completed> {
 
-    override fun handle(event: DomainEvent<SomeEventPayload>) {
+    override fun handle(event: DomainEvent<SomeEventPayload.Completed>) {
         val payload = event.payload
         // 이벤트 처리 로직
     }
 
     override fun supports(payloadType: KClass<*>): Boolean =
-        payloadType == SomeEventPayload::class
+        payloadType == SomeEventPayload.Completed::class
 }
 ```
 

--- a/.claude/skills/event/SKILL.md
+++ b/.claude/skills/event/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: add-or-update-event-handler
+description: Bounded Context에 새로운 도메인 이벤트 핸들러를 추가하거나 수정할 때 사용하세요.
+---
+
+# Add or Update Event Handler
+
+## Instructions
+
+도메인 이벤트 핸들러를 추가하거나 수정할 때 다음 규칙을 따르세요:
+
+### 1. event 디렉토리 위치
+
+이벤트 핸들러는 이벤트를 **수신하는 쪽** BC의 `infrastructure/event/` 디렉토리에 위치합니다. 기능상 필요하지 않다면 이 디렉토리 안에는 파일이 존재하지 않을 수 있습니다.
+
+```
+{bounded-context}/
+└── infrastructure/
+    └── event/
+        └── SomeEventHandler.kt
+```
+
+### 2. 이벤트 시스템 구조
+
+이벤트 관련 공통 인터페이스와 구현체는 `common/` 레이어에 위치합니다:
+
+- `common/event/DomainEvent.kt` — 이벤트 래퍼 인터페이스
+- `common/event/DomainEventHandler.kt` — 핸들러 인터페이스
+- `common/event/DomainEventPublisher.kt` — 발행 인터페이스
+- `common/event/payload/` — 이벤트 페이로드 정의
+- `common/infrastructure/DomainEventDispatcher.kt` — 중앙 디스패처 (Spring `@TransactionalEventListener` 기반)
+
+### 3. 핸들러 작성 규칙
+
+핸들러는 `DomainEventHandler<T>` 인터페이스를 구현하고, `@Component`로 등록합니다. `DomainEventDispatcher`가 자동으로 핸들러를 수집하여 이벤트를 분배합니다.
+
+```kotlin
+@Component
+class SomeEventHandler(
+    private val someRepository: SomeRepository,
+) : DomainEventHandler<SomeEventPayload> {
+
+    override fun handle(event: DomainEvent<SomeEventPayload>) {
+        val payload = event.payload
+        // 이벤트 처리 로직
+    }
+
+    override fun supports(payloadType: KClass<*>): Boolean =
+        payloadType == SomeEventPayload::class
+}
+```
+
+### 4. 페이로드 작성 규칙
+
+이벤트 페이로드는 `common/event/payload/` 디렉토리에 sealed interface로 정의합니다. 페이로드 필드에는 `common/domain/`의 VO 클래스를 사용합니다.
+
+```kotlin
+sealed interface SomeEventPayload {
+    data class Completed(
+        val someId: SomeId,
+        val memberId: MemberId,
+    ) : SomeEventPayload
+}
+```
+
+### 5. 이벤트 발행
+
+이벤트를 발행하는 쪽(주로 application service)에서는 `DomainEventPublisher`를 주입받아 사용합니다.
+
+```kotlin
+@Service
+class SomeService(
+    private val eventPublisher: DomainEventPublisher,
+) {
+    fun doSomething() {
+        // 비즈니스 로직 수행
+        eventPublisher.publish(SomeEventPayload.Completed(...))
+    }
+}
+```
+
+### 6. 주의사항
+
+- 이벤트 핸들러는 **수신하는 BC의 infrastructure**에 위치합니다. 발행하는 BC에 두지 않습니다.
+- 핸들러 내부에서는 자신의 BC의 domain repository/service만 사용합니다.
+- `DomainEventDispatcher`는 `TransactionPhase.BEFORE_COMMIT` 단계에서 실행되므로, 핸들러의 작업은 발행자와 같은 트랜잭션 내에서 수행됩니다.

--- a/.claude/skills/infrastructure/SKILL.md
+++ b/.claude/skills/infrastructure/SKILL.md
@@ -14,10 +14,12 @@ description: Bounded Context에 새로운 infrastructure 를 추가하거나 수
 ```
 └── infrastructure/
     ├── persistence/
-    ├── event/
+    ├── event/          # → 별도 skill(event) 참고
     ├── security/
     └── external/
 ```
+
+> **참고**: `event/` 디렉토리의 상세 작성 규칙은 별도의 `event` skill에 정의되어 있습니다. 이벤트 핸들러를 추가하거나 수정할 때는 해당 skill을 사용하세요.
 
 ### 2. persistence 디렉토리
 

--- a/.claude/skills/infrastructure/SKILL.md
+++ b/.claude/skills/infrastructure/SKILL.md
@@ -14,6 +14,7 @@ description: Bounded Context에 새로운 infrastructure 를 추가하거나 수
 ```
 └── infrastructure/
     ├── persistence/
+    ├── event/
     ├── security/
     └── external/
 ```

--- a/.claude/skills/infrastructure/SKILL.md
+++ b/.claude/skills/infrastructure/SKILL.md
@@ -19,7 +19,7 @@ description: Bounded Context에 새로운 infrastructure 를 추가하거나 수
     └── external/
 ```
 
-> **참고**: `event/` 디렉토리의 상세 작성 규칙은 별도의 `event` skill에 정의되어 있습니다. 이벤트 핸들러를 추가하거나 수정할 때는 해당 skill을 사용하세요.
+> **참고**: `event/` 디렉토리의 상세 작성 규칙은 별도의 `add-or-update-event-handler` skill에 정의되어 있습니다. 이벤트 핸들러를 추가하거나 수정할 때는 해당 skill을 사용하세요.
 
 ### 2. persistence 디렉토리
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -97,6 +97,7 @@ xyz.robinjoon.growweek/
     │   └── service/            # Domain Services
     └── infrastructure/          # Infrastructure Layer (구현체)
         ├── persistence/        # 영속성 구현 (JPA, Repository Impl)
+        ├── event/              # 도메인 이벤트 핸들러
         └── external/           # 외부 시스템 연동
 ```
 
@@ -140,10 +141,12 @@ xyz.robinjoon.growweek/
     - Repository 구현체 (Exposed DSL 쿼리)
     - Redis Repository (캐싱)
     - 데이터베이스 매핑 로직
+  - **event/**:
+    - 다른 BC에서 발행한 도메인 이벤트를 수신하는 핸들러
+    - `DomainEventHandler` 인터페이스 구현체
   - **external/**:
     - OpenFeign 클라이언트 (외부 API 호출)
     - 외부 서비스 어댑터
-    - 외부 이벤트 구독/발행
 - **의존성**: Domain Layer의 인터페이스를 구현
 
 ### Common Layer (common/)


### PR DESCRIPTION
## Summary
- ARCHITECTURE.md 디렉토리 구조 및 계층 상세 설명에 `infrastructure/event/` 공식 반영
- infrastructure skill 디렉토리 구조에 `event/` 추가
- 이벤트 핸들러 작성을 위한 별도 `event` skill 신규 생성 (핸들러 위치, 페이로드 작성, 발행 패턴, 트랜잭션 주의사항 포함)

## Test plan
- [x] 빌드 및 전체 테스트 통과 확인
- [x] 기존 `task/infrastructure/event/` 코드와 문서 정합성 확인
- [x] event skill이 정상 등록되어 사용 가능한지 확인

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)